### PR TITLE
fix: use HuggingFace Hub IDs instead of local model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Smaller chunks = lower latency but more decode overhead. `chunk_size=4` is the s
 ```python
 from qwen3_tts_cuda_graphs import Qwen3TTSCudaGraphs
 
-model = Qwen3TTSCudaGraphs.from_pretrained("models/Qwen3-TTS-12Hz-0.6B-Base")
+model = Qwen3TTSCudaGraphs.from_pretrained("Qwen/Qwen3-TTS-12Hz-0.6B-Base")
 
 # Streaming — yields audio chunks during generation
 for audio_chunk, sr, timing in model.generate_voice_clone_streaming(

--- a/benchmarks/baseline.py
+++ b/benchmarks/baseline.py
@@ -7,7 +7,7 @@ from qwen_tts import Qwen3TTSModel
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_SIZE = os.environ.get('MODEL_SIZE', '0.6B')
-MODEL_PATH = os.path.join(PROJECT_DIR, 'models', f'Qwen3-TTS-12Hz-{MODEL_SIZE}-Base')
+MODEL_ID = f'Qwen/Qwen3-TTS-12Hz-{MODEL_SIZE}-Base'
 text = "Ladies and gentlemen, I have just been informed that this speech is being generated faster than I can speak it. The robots have officially won. Please remain calm."
 ref_audio = os.path.join(PROJECT_DIR, 'ref_audio.wav')
 ref_text = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs."
@@ -15,7 +15,7 @@ ref_text = "I'm confused why some people have super short timelines, yet at the 
 print(f"=== {MODEL_SIZE} Baseline Benchmark ===")
 print(f"GPU: {torch.cuda.get_device_name(0)}")
 print("Loading model...", flush=True)
-model = Qwen3TTSModel.from_pretrained(MODEL_PATH, device_map='cuda:0', dtype=torch.bfloat16, local_files_only=True)
+model = Qwen3TTSModel.from_pretrained(MODEL_ID, device_map='cuda:0', dtype=torch.bfloat16)
 
 # Pre-compute voice clone prompt once (avoids re-encoding ref audio every run)
 print("Building voice clone prompt...", flush=True)

--- a/benchmarks/chunk_sweep.py
+++ b/benchmarks/chunk_sweep.py
@@ -9,14 +9,14 @@ from qwen3_tts_cuda_graphs import Qwen3TTSCudaGraphs
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_SIZE = os.environ.get('MODEL_SIZE', '0.6B')
-MODEL_PATH = os.path.join(PROJECT_DIR, 'models', f'Qwen3-TTS-12Hz-{MODEL_SIZE}-Base')
+MODEL_ID = f'Qwen/Qwen3-TTS-12Hz-{MODEL_SIZE}-Base'
 text = "Ladies and gentlemen, I have just been informed that this speech is being generated faster than I can speak it. The robots have officially won. Please remain calm."
 ref_audio = os.path.join(PROJECT_DIR, 'ref_audio.wav')
 ref_text = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."
 
 print("Loading model...")
 model = Qwen3TTSCudaGraphs.from_pretrained(
-    MODEL_PATH, device='cuda', dtype=torch.bfloat16,
+    MODEL_ID, device='cuda', dtype=torch.bfloat16,
     attn_implementation='eager', max_seq_len=2048,
 )
 

--- a/benchmarks/streaming.py
+++ b/benchmarks/streaming.py
@@ -9,14 +9,14 @@ from qwen3_tts_cuda_graphs import Qwen3TTSCudaGraphs
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_SIZE = os.environ.get('MODEL_SIZE', '0.6B')
-MODEL_PATH = os.path.join(PROJECT_DIR, 'models', f'Qwen3-TTS-12Hz-{MODEL_SIZE}-Base')
+MODEL_ID = f'Qwen/Qwen3-TTS-12Hz-{MODEL_SIZE}-Base'
 text = "Ladies and gentlemen, I have just been informed that this speech is being generated faster than I can speak it. The robots have officially won. Please remain calm."
 ref_audio = os.path.join(PROJECT_DIR, 'ref_audio.wav')
 ref_text = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."
 
 print("Loading model...")
 model = Qwen3TTSCudaGraphs.from_pretrained(
-    MODEL_PATH,
+    MODEL_ID,
     device='cuda',
     dtype=torch.bfloat16,
     attn_implementation='eager',

--- a/benchmarks/throughput.py
+++ b/benchmarks/throughput.py
@@ -9,14 +9,14 @@ from qwen3_tts_cuda_graphs import Qwen3TTSCudaGraphs
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_SIZE = os.environ.get('MODEL_SIZE', '0.6B')
-MODEL_PATH = os.path.join(PROJECT_DIR, 'models', f'Qwen3-TTS-12Hz-{MODEL_SIZE}-Base')
+MODEL_ID = f'Qwen/Qwen3-TTS-12Hz-{MODEL_SIZE}-Base'
 text = "Ladies and gentlemen, I have just been informed that this speech is being generated faster than I can speak it. The robots have officially won. Please remain calm."
 ref_audio = os.path.join(PROJECT_DIR, 'ref_audio.wav')
 ref_text = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."
 
 print("Loading model...")
 model = Qwen3TTSCudaGraphs.from_pretrained(
-    MODEL_PATH,
+    MODEL_ID,
     device='cuda',
     dtype=torch.bfloat16,
     attn_implementation='eager',

--- a/setup.sh
+++ b/setup.sh
@@ -34,27 +34,17 @@ fi
     echo "  uv pip install torch --index-url https://download.pytorch.org/whl/cu124 --python .venv/bin/python"
 }
 
-# Download models
+# Pre-download models to HuggingFace cache
 echo ""
-echo "Downloading models from HuggingFace Hub..."
+echo "Pre-downloading models to HuggingFace cache..."
 .venv/bin/python -c "
 from huggingface_hub import snapshot_download
-import os
-
-models_dir = os.path.join('$DIR', 'models')
-os.makedirs(models_dir, exist_ok=True)
 
 for model in ['Qwen3-TTS-12Hz-0.6B-Base', 'Qwen3-TTS-12Hz-1.7B-Base']:
-    dest = os.path.join(models_dir, model)
-    has_weights = os.path.exists(dest) and any(
-        f.endswith(('.safetensors', '.bin')) for f in os.listdir(dest)
-    )
-    if has_weights:
-        print(f'  {model}: already downloaded')
-    else:
-        print(f'  {model}: downloading...')
-        snapshot_download(f'Qwen/{model}', local_dir=dest)
-        print(f'  {model}: done')
+    repo_id = f'Qwen/{model}'
+    print(f'  {repo_id}: downloading...')
+    snapshot_download(repo_id)
+    print(f'  {repo_id}: done')
 "
 
 # Generate ref audio if missing


### PR DESCRIPTION
## Summary
- Replace local `models/Qwen3-TTS-12Hz-*` paths with Hub IDs (`Qwen/Qwen3-TTS-12Hz-*`) across all 4 benchmarks, README, and setup.sh
- Fix bug in `model.py` where the config fallback branch referenced `predictor` before it was defined — now always extracts config from the already-loaded model
- Remove `local_files_only=True` from baseline benchmark
- Setup script now pre-downloads to HF cache instead of a local `models/` directory

## Test plan
- [ ] Run `./benchmark.sh 0.6B` and verify model loads from HF Hub cache
- [ ] Run `./setup.sh` on a fresh machine and verify models download to HF cache