### PR TITLE
fix: prevent ICL phoneme bleed-through at generation start

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ audio_list, sr = model.generate_voice_clone(
 
 The CUDA graphs are unchanged — both predictor and talker graphs are replayed per step. The streaming generator yields codec ID chunks every `chunk_size` steps, and the model wrapper decodes each chunk to audio using a sliding window with 25-frame left context (matching the upstream codec's `chunked_decode` pattern) to avoid boundary artifacts.
 
+## Voice Cloning: ICL Phoneme Artifact
+
+In ICL (In-Context Learning) mode — the default voice cloning path — the model's prefill sequence ends with the last codec token of the reference audio. The model conditions its **first generated token** on whatever phoneme the reference audio happens to end on. If the reference ends mid-word or on a consonant cluster, that phoneme bleeds into the very start of the generated speech.
+
+**The fix is applied automatically.** The wrapper appends 0.5 seconds of silence to the reference audio before encoding it. This ensures the last codec tokens in the prefill represent silence, giving the model a clean starting point regardless of how the reference recording ends — no changes to your calling code required.
+
 ## Voice Cloning with Precomputed Speaker Embeddings
 
 For production use, extract the speaker embedding once and reuse it:


### PR DESCRIPTION
## What

In ICL voice-cloning mode, the model's prefill sequence ends with the last codec token of the reference audio. This means the model's **first generated token is conditioned on whatever phoneme the reference recording ends on** — causing a brief, consistent artifact at the very start of every generated sample (something like a "thumbs" or "comes" sound depending on the reference).

## Why it happens

The ICL prompt sums text and reference codec embeddings by position, and the last position before generation starts is the last frame of the reference audio. The model reads that as the acoustic context it's continuing from, and generates a token that completes or continues that phoneme.

## Fix

Append 0.5 seconds of silence to the reference audio before encoding it. When the last codec tokens represent silence, the model starts generation from acoustic silence and produces clean output from the first frame — regardless of how the reference recording ends.

Applied automatically in `_load_ref_audio_with_silence()`, called from `_prepare_generation()`. No changes required at the call site.

## Changes

- `qwen3_tts_cuda_graphs/model.py`: add `_load_ref_audio_with_silence()` helper; use it in `_prepare_generation()` instead of passing the raw file path
- `README.md`: document the artifact and the automatic fix
- `BLOG.md`: add "An Unexpected Discovery: The ICL Phoneme Artifact" section explaining the mechanism and fix