### PR TITLE
fix(model): prepend ref_codes before decoding in ICL voice clone mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["faster_qwen3_tts*"]
 
 [project]
 name = "faster-qwen3-tts"
-version = "0.1.1"
+version = "0.1.2"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- The 12Hz codec uses `chunked_decode`, a causal decoder that needs previous tokens as acoustic context
- In ICL/advanced mode (`xvec_only=False`), the official qwen-tts implementation prepends the reference audio's codec tokens before decoding and trims the reference portion from the output — we were skipping this entirely
- The talker model was generating the right tokens (correctly conditioned on the reference during prefill), but the codec decoder had no voice context and started cold
- This explains why advanced cloning 'worked' but sounded noticeably worse and less consistent than the official demo

**Fix:** `_prepare_generation` now returns `ref_codes` (8th value; `None` for `xvec_only=True`). Both `generate_voice_clone` and `generate_voice_clone_streaming` prepend ref_codes before decode and trim the reference audio portion from the output.

Bumps version to 0.1.2.

## Test plan

- [ ] `generate_voice_clone(..., xvec_only=False)` produces audio that sounds clearly more like the reference voice
- [ ] `generate_voice_clone(..., xvec_only=True)` (default) unchanged — ref_codes is None, no prepend/trim
- [ ] Streaming (`generate_voice_clone_streaming`) works correctly end-to-end
- [ ] Demo advanced clone mode improved
