### PR TITLE
feat: Add native Windows setup and benchmark scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Benchmarks include tokenization + inference (apples-to-apples with baseline). RT
 | Jetson AGX Orin 64GB | 0.179 | 3,641ms | 1.307 | 597ms | 7.3x / 6.1x |
 | DGX Spark (GB10) | 1.17 | 567ms | 2.56 | 280ms | 2.2x / 2.0x |
 | RTX 4090 | 0.82 | 800ms | **4.78** | **156ms** | 5.8x / 5.1x |
+| RTX 4060 (Windows) | 0.23 | 2,697ms | **2.26** | **413ms** | 9.8x / 6.5x |
 | H100 80GB HBM3 | 0.435 | 1,474ms | **3.884** | **228ms** | 8.9x / 6.5x |
 
 ### 1.7B Model
@@ -132,6 +133,7 @@ Benchmarks include tokenization + inference (apples-to-apples with baseline). RT
 | Jetson AGX Orin 64GB | 0.183 | 3,573ms | 1.089 | 693ms | 6.0x / 5.2x |
 | DGX Spark (GB10) | 1.01 | 661ms | 1.87 | 400ms | 1.9x / 1.7x |
 | RTX 4090 | 0.82 | 850ms | **4.22** | **174ms** | 5.1x / 4.9x |
+| RTX 4060 (Windows) | 0.23 | 2,905ms | **1.83** | **460ms** | 7.9x / 6.3x |
 | H100 80GB HBM3 | 0.439 | 1,525ms | **3.304** | **241ms** | 7.5x / 6.3x |
 
 **Note:** Baseline TTFA values are **streaming TTFA** from the community `Qwen3-TTS-streaming` fork (which adds streaming) or from our **dynamic-cache parity streaming** path (no CUDA graphs) where available. The official `Qwen3-TTS` repo does **not** currently support streaming, so without a streaming baseline TTFA would be **time-to-full-audio**. CUDA graphs uses `generate_voice_clone_streaming(chunk_size=8)` for TTFA. Both include text tokenization for fair comparison. Speedup shows throughput / TTFA improvement. The streaming fork reports additional speedups that appear tied to `torch.compile`; we couldn’t reproduce those on Jetson-class devices where `torch.compile` isn’t available.
@@ -142,11 +144,22 @@ Benchmarks include tokenization + inference (apples-to-apples with baseline). RT
 
 Benchmarks run from source. You only need [uv](https://docs.astral.sh/uv/) and `./setup.sh`:
 
+**Linux / macOS / WSL:**
+
 ```bash
 git clone https://github.com/andimarafioti/faster-qwen3-tts
 cd faster-qwen3-tts
 ./setup.sh
 ./benchmark.sh # or ./benchmark.sh 0.6B or ./benchmark.sh 1.7B for a single model
+```
+
+**Windows (Native):**
+
+```cmd
+git clone https://github.com/andimarafioti/faster-qwen3-tts
+cd faster-qwen3-tts
+setup_windows.bat
+benchmark_windows.bat   # or benchmark_windows.bat 0.6B / 1.7B / both
 ```
 
 Results are saved as `bench_results_<GPU_NAME>.json` and audio samples as `sample_0.6B.wav` / `sample_1.7B.wav`.
@@ -334,7 +347,6 @@ QWEN_TTS_MODEL=Qwen/Qwen3-TTS-12Hz-0.6B-Base
 QWEN_TTS_CUSTOM_MODEL=Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
 QWEN_TTS_VOICE_DESIGN_MODEL=Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
 ```
-
 ## How It Works
 
 Qwen3-TTS runs two autoregressive transformers per decode step:

--- a/WINDOWS_SETUP_GUIDE.md
+++ b/WINDOWS_SETUP_GUIDE.md
@@ -1,0 +1,74 @@
+# Windows Setup Guide for Faster Qwen3-TTS
+
+The original `setup.sh` script is designed for Unix/Linux systems. This guide provides instructions for setting up and running Faster Qwen3-TTS natively on Windows.
+
+## Quick Start (Recommended)
+
+### 1. Run the Setup Script
+Open Command Prompt and navigate to the project directory, then run:
+
+```cmd
+setup_windows.bat
+```
+
+This script will:
+- Detect if `uv` is installed (recommended for 10x faster setup)
+- Create a virtual environment (`.venv`)
+- Install all dependencies (including PyTorch with CUDA)
+- Pre-download the Qwen3-TTS models
+- Generate a placeholder `ref_audio.wav`
+
+### 2. Run the Benchmark
+After setup completes, you can run the benchmark:
+
+```cmd
+benchmark_windows.bat
+```
+
+Additional usage for the benchmark:
+```cmd
+benchmark_windows.bat 0.6B    # Benchmark only the 0.6B model
+benchmark_windows.bat 1.7B    # Benchmark only the 1.7B model
+benchmark_windows.bat custom  # Benchmark CustomVoice mode
+benchmark_windows.bat both    # Benchmark both (default)
+```
+
+## Manual Setup
+
+If you prefer to set up manually:
+
+```cmd
+# Create virtual environment
+python -m venv .venv
+
+# Activate it
+.venv\Scripts\activate
+
+# Install dependencies
+pip install --upgrade pip
+pip install -e .
+
+# Install flash-attn (optional, requires compiler)
+pip install flash-attn
+
+# Download models
+python -c "from huggingface_hub import snapshot_download; [snapshot_download(f'Qwen/{m}') for m in ['Qwen3-TTS-12Hz-0.6B-Base', 'Qwen3-TTS-12Hz-1.7B-Base']]"
+```
+
+## Troubleshooting
+
+### CUDA Issues
+If `setup_windows.bat` warns that CUDA is not available:
+1. Verify you have an NVIDIA GPU and recent drivers.
+2. Run `nvidia-smi` to check CUDA support.
+3. You may need to manually install the CUDA version of PyTorch:
+   ```cmd
+   .venv\Scripts\pip install torch --index-url https://download.pytorch.org/whl/cu124
+   ```
+
+### Python Not Found
+Ensure Python 3.10 or later is installed and added to your system PATH.
+
+## Performance Notes
+- **CUDA Required**: For real-time performance, an NVIDIA GPU is required.
+- **uv**: Highly recommended for faster installation. Install it via `pip install uv` or from [astral.sh](https://docs.astral.sh/uv/).

--- a/benchmark_windows.bat
+++ b/benchmark_windows.bat
@@ -1,0 +1,70 @@
+@echo off
+setlocal enabledelayedexpansion
+REM Benchmark Qwen3-TTS with CUDA Graphs (Windows)
+REM Usage: .\benchmark_windows.bat [0.6B|1.7B|both|custom]
+
+set "DIR=%~dp0"
+cd /d "%DIR%"
+
+set "MODEL=%~1"
+if "%MODEL%"=="" set "MODEL=both"
+
+set "PY=.\.venv\Scripts\python.exe"
+
+if not exist "!PY!" (
+    echo ERROR: venv not found. Run .\setup_windows.bat first.
+    pause
+    exit /b 1
+)
+
+!PY! -c "import torch; assert torch.cuda.is_available()" 2>nul || (
+    echo ERROR: PyTorch with CUDA required. Check your venv.
+    pause
+    exit /b 1
+)
+
+for /f "tokens=*" %%i in ('!PY! -c "import torch; print(torch.cuda.get_device_name(0))"') do set "GPU_NAME=%%i"
+for /f "tokens=*" %%i in ('!PY! -c "import torch; print(torch.__version__)"') do set "PYTORCH_VER=%%i"
+for /f "tokens=*" %%i in ('!PY! -c "import torch; print(torch.version.cuda)"') do set "CUDA_VER=%%i"
+
+echo === Faster Qwen3-TTS Benchmark ===
+echo GPU: %GPU_NAME%
+echo PyTorch: %PYTORCH_VER%
+echo CUDA: %CUDA_VER%
+echo.
+
+if /i "%MODEL%"=="0.6B" (
+    call :run_model 0.6B
+) else if /i "%MODEL%"=="1.7B" (
+    call :run_model 1.7B
+) else if /i "%MODEL%"=="custom" (
+    call :run_custom 0.6B
+    call :run_custom 1.7B
+) else if /i "%MODEL%"=="both" (
+    call :run_model 0.6B
+    call :run_model 1.7B
+) else (
+    echo Usage: .\benchmark_windows.bat [0.6B^|1.7B^|both^|custom]
+    pause
+    exit /b 1
+)
+
+echo Done. Results saved as bench_results_*.json
+pause
+goto :eof
+
+:run_model
+set "size=%~1"
+echo --- Benchmarking %size% ---
+set "MODEL_SIZE=%size%"
+!PY! "benchmarks\throughput.py"
+echo.
+goto :eof
+
+:run_custom
+set "size=%~1"
+echo --- Benchmarking %size% (CustomVoice) ---
+set "MODEL_SIZE=%size%"
+!PY! "benchmarks\custom_voice.py"
+echo.
+goto :eof

--- a/setup_windows.bat
+++ b/setup_windows.bat
@@ -1,0 +1,84 @@
+@echo off
+setlocal enabledelayedexpansion
+REM Setup script for faster-qwen3-tts (Windows)
+REM Creates a venv (prefers uv), installs deps, and downloads models
+
+set "DIR=%~dp0"
+cd /d "%DIR%"
+
+echo === Faster Qwen3-TTS Setup ===
+
+REM Check for uv
+where uv >nul 2>&1
+if %errorlevel% equ 0 (
+    set "HAS_UV=1"
+    echo Found uv, using it for faster setup.
+) else (
+    set "HAS_UV=0"
+    echo uv not found, falling back to standard pip.
+)
+
+REM Check Python is available if no uv
+if !HAS_UV! equ 0 (
+    where python >nul 2>&1
+    if %errorlevel% neq 0 (
+        echo ERROR: Python not found. install it or uv: https://docs.astral.sh/uv/getting-started/installation/
+        pause
+        exit /b 1
+    )
+)
+
+REM Create venv + install deps (skip if venv already exists)
+if exist ".venv\Scripts\python.exe" (
+    echo Venv already exists, skipping install. Delete .venv to force reinstall.
+) else (
+    echo Creating venv and installing dependencies...
+    if !HAS_UV! equ 1 (
+        uv venv .venv --python 3.10
+        echo Installing PyTorch with CUDA support...
+        uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124 --python .venv\Scripts\python.exe
+        uv pip install -e . --python .venv\Scripts\python.exe
+        
+        echo Attempting to install flash-attn ^(optional^)...
+        uv pip install flash-attn --python .venv\Scripts\python.exe 2>nul && echo   flash-attn installed || echo   flash-attn not available ^(ok, will use manual attention^)
+    ) else (
+        python -m venv .venv
+        call .venv\Scripts\activate.bat
+        python -m pip install --upgrade pip
+        echo Installing PyTorch with CUDA support...
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+        pip install -e .
+        
+        echo Attempting to install flash-attn ^(optional^)...
+        pip install flash-attn 2>nul && echo   flash-attn installed || echo   flash-attn not available ^(ok, will use manual attention^)
+        call deactivate
+    )
+)
+
+REM Verify CUDA
+echo.
+.venv\Scripts\python.exe -c "import torch; assert torch.cuda.is_available(), 'CUDA not available'; print(f'PyTorch {torch.__version__}, CUDA {torch.version.cuda}, GPU: {torch.cuda.get_device_name(0)}')" || (
+    echo.
+    echo WARNING: CUDA not available. You may need to install a CUDA-enabled PyTorch wheel.
+    echo   .venv\Scripts\pip install torch --index-url https://download.pytorch.org/whl/cu124
+)
+
+REM Pre-download models to HuggingFace cache
+echo.
+echo Pre-downloading models to HuggingFace cache...
+.venv\Scripts\python.exe -c "from huggingface_hub import snapshot_download; [snapshot_download(f'Qwen/{m}') for m in ['Qwen3-TTS-12Hz-0.6B-Base', 'Qwen3-TTS-12Hz-1.7B-Base']]"
+
+REM Generate ref audio if missing
+if not exist "ref_audio.wav" (
+    echo.
+    echo Generating placeholder reference audio...
+    .venv\Scripts\python.exe -c "import numpy as np, soundfile as sf; sr = 16000; t = np.linspace(0, 1.0, sr, dtype=np.float32); audio = 0.3 * np.sin(2 * 3.14159 * 440 * t); sf.write('ref_audio.wav', audio, sr)"
+    echo   Generated placeholder ref_audio.wav ^(replace with real speech for best quality^)
+)
+
+echo.
+echo === Setup complete ===
+echo Activate the venv: .venv\Scripts\activate
+echo Run benchmark:     .\benchmark_windows.bat
+echo.
+pause


### PR DESCRIPTION
This PR adds native Windows support for environment setup and benchmarking, matching the functionality of the existing Unix scripts. 

**Changes:**
- Added [setup_windows.bat]: Robust setup script that detects `uv` (for 10x faster installs), handles CUDA-enabled PyTorch correctly, and pre-downloads models.
- Added [benchmark_windows.bat]: Standardized benchmarking script with full argument parity vs [benchmark.sh] (`0.6B`, `1.7B`, `both`, [custom].
- Updated [README.md] and [WINDOWS_SETUP_GUIDE.md]: Standardized Windows instructions and added real-world results for the RTX 4060.

**Verification (RTX 4060 on Windows):**

| Model | Baseline TTFA | Fast TTFA | Speedup |
|---|---|---|---|
| **0.6B** | 2,697ms | 413ms | **6.5x** |
| **1.7B** | 2,905ms | 460ms | **6.3x** |

All scripts have been tested for syntax and reliability on native Windows.

<img width="1079" height="918" alt="image" src="https://github.com/user-attachments/assets/bba54401-e4fc-4137-b240-8725867254b4" />
<img width="1085" height="406" alt="image" src="https://github.com/user-attachments/assets/01ca5114-dd7b-41bb-9ca0-fb92a86cf106" />

[bench_results_NVIDIA_GeForce_RTX_4060.json](https://github.com/user-attachments/files/25585331/bench_results_NVIDIA_GeForce_RTX_4060.json)
