### PR TITLE
fix: clone ref_code to escape inference_mode context in ICL mode

### DIFF
--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -422,7 +422,7 @@ class FasterQwen3TTS:
                 icl_input_embed, trailing_text_hidden = m.generate_icl_prompt(
                     text_id=input_id[:, 3:-5],
                     ref_id=ref_ids[index][:, 3:-2],
-                    ref_code=voice_clone_prompt["ref_code"][index].to(m.talker.device),
+                    ref_code=voice_clone_prompt["ref_code"][index].to(m.talker.device).clone(),  # escape inference_mode context
                     tts_pad_embed=tts_pad_embed,
                     tts_eos_embed=tts_eos_embed,
                     non_streaming_mode=non_streaming_mode,


### PR DESCRIPTION
## Problem

When `generate_voice_clone()` is called with `xvec_only=False` (ICL mode), it crashes with:

```
RuntimeError: Inference tensors cannot be saved for backward. To work around
you can make a clone to get a normal tensor and use autograd on the clone.
```

### Root cause

`_prepare_generation()` calls `self.model.create_voice_clone_prompt()` from the `qwen_tts` library. That method is decorated with `@torch.inference_mode()`, so the returned `ref_code` tensor is an **inference tensor**.

The tensor is stored in `_voice_prompt_cache`. Later, `_build_talker_inputs_local()` passes it to `m.generate_icl_prompt()`:

```python
# faster_qwen3_tts/model.py, line 425 (before fix)
ref_code=voice_clone_prompt["ref_code"][index].to(m.talker.device),
```

Inside `generate_icl_prompt()`, the tensor is fed to `nn.Embedding` via `self.talker.get_input_embeddings()`. `nn.Embedding` requires a normal (non-inference) tensor, triggering the error.

## Fix

Call `.clone()` after `.to(device)` to escape the `inference_mode` context:

```python
# faster_qwen3_tts/model.py, line 425 (after fix)
ref_code=voice_clone_prompt["ref_code"][index].to(m.talker.device).clone(),
```

`.clone()` creates a normal tensor that is no longer bound to the `inference_mode` context, allowing `nn.Embedding` to accept it.

## Notes

- This fix only affects the ICL code path (`xvec_only=False`). The `xvec_only=True` path is unaffected.
- With the current **0.6B model**, ICL mode still generates unexpected output (~292 s of audio with no EOS). This appears to be a model-level limitation, not a library bug, and is a separate issue from this crash fix.

## Reproduction

```python
from faster_qwen3_tts import FasterQwen3TTS
import torch

model = FasterQwen3TTS.from_pretrained("Qwen/Qwen3-TTS-12Hz-0.6B-Base", device="cuda", dtype=torch.bfloat16)

# This raises RuntimeError without the fix
audio_list, sr = model.generate_voice_clone(
    text="Hello world.",
    language="English",
    ref_audio="ref.wav",
    ref_text="Your reference text here.",
    xvec_only=False,  # ICL mode
)
```