### PR TITLE
fix(demo): prevent stale preset from overriding browser recordings in ICL mode

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1274,7 +1274,6 @@ function pickRef(input) { const f = input.files[0]; if (f) setRef(f); }
 function setRef(f) {
   clearPresetSelection();
   refFile = f;
-  setXvec(true); // user audio has no verified transcript — default to Simple (xvec) mode
   $('refLabel').textContent = f.name;
   $('refChip').classList.add('has');
   const prev = $('recPreview');


### PR DESCRIPTION
## Summary

- **Fix ICL voice cloning with browser recordings**: `stopRec()` didn't call `clearPresetSelection()`, so selecting a preset then recording audio would still send the preset's `ref_audio` to the server — paired with the recording's transcript — causing completely broken ICL output
- **Default demo UI to Simple (xvec) mode**: safer default; presets auto-switch to Advanced (ICL), uploads/recordings default to Simple
- **Record at 24kHz**: matches the codec's native sample rate (was 16kHz)
- Includes prior commits: SDPA fix for BF16/StaticCache divergence, class-scope test fixtures for OOM, version bump to 0.2.4

## Test plan
- [x] Record audio in browser → generate with Advanced (ICL) mode → server receives recording (not preset)
- [x] Preset selection → generate with ICL → still works
- [x] Verified no stale diagnostic logging left in server.py or model.py