### PR TITLE
Fix sample-rate mismatch causing low/slow audio in OpenAI server

### DIFF
--- a/faster_qwen3_tts/cli.py
+++ b/faster_qwen3_tts/cli.py
@@ -39,7 +39,7 @@ def _stream_to_audio(gen):
     for audio_chunk, sr, _ in gen:
         chunks.append(audio_chunk)
     if not chunks:
-        return np.zeros(1, dtype=np.float32), 12000
+        return np.zeros(1, dtype=np.float32), 24000
     return np.concatenate(chunks), sr
 
 

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -42,9 +42,31 @@ class FasterQwen3TTS:
         self.device = device
         self.dtype = dtype
         self.max_seq_len = max_seq_len
-        self.sample_rate = 12000  # Qwen3-TTS uses 12kHz
+        self.sample_rate = self._infer_sample_rate(base_model)
         self._warmed_up = False
         self._voice_prompt_cache = {}  # Cache (ref_audio, ref_text) -> (vcp, ref_ids)
+
+    @staticmethod
+    def _infer_sample_rate(base_model) -> int:
+        """Infer output audio sample rate from qwen-tts internals."""
+        # Qwen3-TTS model IDs include "12Hz", but that is codec frame-rate (tokens/s),
+        # not waveform sampling rate. Generated audio is 24kHz.
+        sample_rate = None
+
+        speech_tokenizer = getattr(getattr(base_model, "model", None), "speech_tokenizer", None)
+        if speech_tokenizer is not None:
+            sample_rate = getattr(speech_tokenizer, "sample_rate", None)
+
+        if sample_rate is None:
+            sample_rate = getattr(base_model, "sample_rate", None)
+
+        if sample_rate is None:
+            logger.warning(
+                "Could not infer sample rate from base model; defaulting to 24000 Hz."
+            )
+            return 24000
+
+        return int(sample_rate)
         
     @classmethod
     def from_pretrained(

--- a/tests/test_sample_rate.py
+++ b/tests/test_sample_rate.py
@@ -1,0 +1,29 @@
+import types
+
+from faster_qwen3_tts.model import FasterQwen3TTS
+
+
+def _dummy_graph():
+    return object()
+
+
+def test_uses_speech_tokenizer_sample_rate_when_available():
+    base_model = types.SimpleNamespace(
+        model=types.SimpleNamespace(
+            speech_tokenizer=types.SimpleNamespace(sample_rate=24000),
+        )
+    )
+    model = FasterQwen3TTS(base_model, _dummy_graph(), _dummy_graph())
+    assert model.sample_rate == 24000
+
+
+def test_falls_back_to_base_model_sample_rate():
+    base_model = types.SimpleNamespace(sample_rate=22050)
+    model = FasterQwen3TTS(base_model, _dummy_graph(), _dummy_graph())
+    assert model.sample_rate == 22050
+
+
+def test_defaults_to_24khz_when_sample_rate_unavailable():
+    base_model = types.SimpleNamespace(model=types.SimpleNamespace())
+    model = FasterQwen3TTS(base_model, _dummy_graph(), _dummy_graph())
+    assert model.sample_rate == 24000


### PR DESCRIPTION
## Summary
- infer `FasterQwen3TTS.sample_rate` from the loaded base model instead of hardcoding 12000
- prefer `base_model.model.speech_tokenizer.sample_rate`, then `base_model.sample_rate`, fallback to 24000
- align CLI empty-stream fallback sample rate to 24000
- add regression tests for all inference/fallback paths

## Why
Issue #50 reports generated WAVs from `examples/openai_server.py` sounding too low/slow.
Root cause was reporting 12000 Hz in metadata while decoded PCM is 24000 Hz.

Closes #50

## Validation
- `.venv/bin/pytest -q`
  - result: 17 passed, 1 warning
