### PR TITLE
feat: accept precomputed voice_clone_prompt in public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,10 @@ The speaker embedding is a 4KB file (2048-dim bf16 vector). In `x_vector_only` m
 - **Shorter prefill**: 10 tokens vs ~80+ in full ICL clone mode
 - **No ref audio at runtime**: just the 4KB embedding file
 
-You can now pass this precomputed prompt directly to the public APIs:
+You can now pass a precomputed prompt directly to the public APIs. The wrapper
+accepts either:
+- the raw `prompt_items` list returned by `create_voice_clone_prompt(...)`
+- or the lower-level dict form produced by `_prompt_items_to_voice_clone_prompt(...)`
 
 ```python
 import torch
@@ -421,18 +424,25 @@ from faster_qwen3_tts import FasterQwen3TTS
 
 model = FasterQwen3TTS.from_pretrained("Qwen/Qwen3-TTS-12Hz-1.7B-Base")
 
-# 1) Compute spk_emb once from reference audio
+# 1) Compute prompt_items once from reference audio
 prompt_items = model.model.create_voice_clone_prompt(
     ref_audio="voice.wav",
     ref_text="",
     x_vector_only_mode=True,
 )
+
+# 2) You can pass prompt_items directly
+audio_list, sr = model.generate_voice_clone(
+    text="Hello world!",
+    language="English",
+    voice_clone_prompt=prompt_items,
+)
+
+# 3) Or save just the speaker embedding and rebuild the compact dict form
 spk_emb = prompt_items[0].ref_spk_embedding
 
-# 2) Save for reuse across restarts
 torch.save(spk_emb.detach().cpu(), "speaker.pt")
 
-# 3) Load and pass it to voice_clone_prompt
 spk_emb = torch.load("speaker.pt", weights_only=True).to(model.device)
 
 voice_clone_prompt = {
@@ -442,8 +452,6 @@ voice_clone_prompt = {
 audio_list, sr = model.generate_voice_clone(
     text="Hello world!",
     language="English",
-    ref_audio="ignored_when_voice_clone_prompt_is_set.wav",
-    ref_text="ignored_when_voice_clone_prompt_is_set",
     voice_clone_prompt=voice_clone_prompt,
 )
 ```

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -6,7 +6,7 @@ CUDA graphs for 6-10x speedup.
 """
 import logging
 from pathlib import Path
-from typing import Any, Dict, Generator, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 import soundfile as sf
@@ -206,7 +206,7 @@ class FasterQwen3TTS:
         ref_text: str,
         xvec_only: bool,
         append_silence: bool,
-        voice_clone_prompt: Optional[Dict[str, Any]],
+        voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]],
     ) -> Tuple[Dict[str, Any], list, bool]:
         """Resolve voice clone prompt data and return (prompt, ref_ids, using_icl_mode)."""
         if voice_clone_prompt is not None:
@@ -230,8 +230,32 @@ class FasterQwen3TTS:
         self,
         input_ids,
         ref_text: str,
-        voice_clone_prompt: Dict[str, Any],
+        voice_clone_prompt: Union[Dict[str, Any], List[Any]],
     ) -> Tuple[Dict[str, Any], list, bool]:
+        if isinstance(voice_clone_prompt, list):
+            if len(voice_clone_prompt) != len(input_ids):
+                raise ValueError(
+                    f"voice_clone_prompt must have length {len(input_ids)}, got {len(voice_clone_prompt)}"
+                )
+
+            vcp = self.model._prompt_items_to_voice_clone_prompt(voice_clone_prompt)
+            ref_ids = []
+            for item in voice_clone_prompt:
+                if bool(item.icl_mode):
+                    item_ref_text = item.ref_text if item.ref_text else ref_text
+                    if not item_ref_text:
+                        raise ValueError(
+                            "ref_text is required when voice_clone_prompt uses ICL mode."
+                        )
+                    ref_id = self.model._tokenize_texts(
+                        [self.model._build_ref_text(item_ref_text)]
+                    )[0]
+                    ref_ids.append(ref_id)
+                else:
+                    ref_ids.append(None)
+
+            return vcp, ref_ids, any(vcp["icl_mode"])
+
         required_keys = ("ref_spk_embedding",)
         missing = [k for k in required_keys if k not in voice_clone_prompt]
         if missing:
@@ -348,13 +372,13 @@ class FasterQwen3TTS:
     def _prepare_generation(
         self,
         text: str,
-        language: str,
         ref_audio: Optional[Union[str, Path]] = None,
         ref_text: str = "",
+        language: str = "English",
         xvec_only: bool = True,
         non_streaming_mode: bool = False,
         append_silence: bool = True,
-        voice_clone_prompt: Optional[Dict[str, Any]] = None,
+        voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
         instruct: Optional[str] = None,
     ):
         """Prepare inputs for generation (shared by streaming and non-streaming).
@@ -684,7 +708,6 @@ class FasterQwen3TTS:
         language: str,
         ref_audio: Optional[Union[str, Path]] = None,
         ref_text: str = "",
-        voice_clone_prompt: Optional[Dict[str, Any]] = None,
         max_new_tokens: int = 2048,
         min_new_tokens: int = 2,
         temperature: float = 0.9,
@@ -696,6 +719,7 @@ class FasterQwen3TTS:
         non_streaming_mode: bool = True,
         append_silence: bool = True,
         instruct: Optional[str] = None,
+        voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> Tuple[list, int]:
         """
         Generate speech with voice cloning using reference audio.
@@ -806,7 +830,6 @@ class FasterQwen3TTS:
         language: str,
         ref_audio: Optional[Union[str, Path]] = None,
         ref_text: str = "",
-        voice_clone_prompt: Optional[Dict[str, Any]] = None,
         max_new_tokens: int = 2048,
         min_new_tokens: int = 2,
         temperature: float = 0.9,
@@ -820,6 +843,7 @@ class FasterQwen3TTS:
         append_silence: bool = True,
         parity_mode: bool = False,
         instruct: Optional[str] = None,
+        voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         """
         Stream voice-cloned speech generation, yielding audio chunks.

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -25,7 +25,12 @@ def _build_dummy_model():
         raise AssertionError("create_voice_clone_prompt should not be called when voice_clone_prompt is provided")
 
     base.create_voice_clone_prompt = _fail
-    base._prompt_items_to_voice_clone_prompt = _fail
+    base._prompt_items_to_voice_clone_prompt = lambda prompt_items: {
+        "ref_code": [item.ref_code for item in prompt_items],
+        "ref_spk_embedding": [item.ref_spk_embedding for item in prompt_items],
+        "x_vector_only_mode": [item.x_vector_only_mode for item in prompt_items],
+        "icl_mode": [item.icl_mode for item in prompt_items],
+    }
 
     model = FasterQwen3TTS(base, _dummy_graph(), _dummy_graph(), device="cpu", dtype=torch.float32)
     model._build_talker_inputs_local = lambda **_kwargs: (
@@ -49,6 +54,10 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     sig_stream = inspect.signature(FasterQwen3TTS.generate_voice_clone_streaming)
     assert "voice_clone_prompt" in sig_clone.parameters
     assert "voice_clone_prompt" in sig_stream.parameters
+    assert list(sig_clone.parameters).index("max_new_tokens") == 5
+    assert list(sig_stream.parameters).index("max_new_tokens") == 5
+    assert list(sig_clone.parameters)[-1] == "voice_clone_prompt"
+    assert list(sig_stream.parameters)[-1] == "voice_clone_prompt"
 
 
 def test_prepare_generation_uses_precomputed_xvec_prompt_without_prompt_extraction():
@@ -95,6 +104,29 @@ def test_prepare_generation_accepts_icl_prompt_with_ref_text():
         language="English",
         voice_clone_prompt=icl_prompt,
     )
+    assert ref_codes is not None
+
+
+def test_prepare_generation_accepts_upstream_prompt_items():
+    model = _build_dummy_model()
+    prompt_items = [
+        types.SimpleNamespace(
+            ref_code=torch.zeros(2, 16, dtype=torch.long),
+            ref_spk_embedding=torch.zeros(1, 4, dtype=torch.float32),
+            x_vector_only_mode=False,
+            icl_mode=True,
+            ref_text="reference text from prompt item",
+        )
+    ]
+
+    _m, _talker, _config, _tie, _tam, _tth, _tpe, ref_codes = model._prepare_generation(
+        text="hello",
+        ref_audio=None,
+        ref_text="",
+        language="English",
+        voice_clone_prompt=prompt_items,
+    )
+
     assert ref_codes is not None
 
 


### PR DESCRIPTION
## Summary
- add optional `voice_clone_prompt` parameter to `generate_voice_clone` and `generate_voice_clone_streaming`
- wire the prompt through `_prepare_generation` so precomputed prompts skip runtime prompt extraction from `ref_audio`
- validate prompt structure/mode consistency and enforce `ref_text` for ICL prompts
- add focused API tests for signature exposure and validation paths
- document public usage in README

Closes #55.

## Validation
- `.venv/bin/python -m pytest -q`
- Result: `21 passed, 1 warning`
