### PR TITLE
fix transformers 5.x API breaks in StaticCache and DynamicCache

### DIFF
--- a/faster_qwen3_tts/predictor_graph.py
+++ b/faster_qwen3_tts/predictor_graph.py
@@ -83,7 +83,7 @@ class PredictorGraph:
         dummy_k = torch.zeros(1, num_kv_heads, 1, head_dim, dtype=self.dtype, device=self.device)
         for layer in self.static_cache.layers:
             if not layer.is_initialized:
-                layer.lazy_initialization(dummy_k)
+                layer.lazy_initialization(dummy_k, dummy_k)
 
     def _make_attn_mask(self, input_embeds: torch.Tensor, cache_position: torch.Tensor):
         mask = create_causal_mask(

--- a/faster_qwen3_tts/talker_graph.py
+++ b/faster_qwen3_tts/talker_graph.py
@@ -66,7 +66,7 @@ class TalkerGraph:
         dummy_k = torch.zeros(1, num_kv_heads, 1, head_dim, dtype=self.dtype, device=self.device)
         for layer in self.static_cache.layers:
             if not layer.is_initialized:
-                layer.lazy_initialization(dummy_k)
+                layer.lazy_initialization(dummy_k, dummy_k)
 
     def _build_attention_masks(self, attention_mask: torch.Tensor | None = None):
         dummy = torch.zeros(1, 1, self.hidden_size, dtype=self.dtype, device=self.device)
@@ -158,7 +158,8 @@ class TalkerGraph:
         self.static_cache.reset()
         seq_len = 0
         for li in range(self.num_layers):
-            k, v = past_key_values[li]  # each [1, kv_heads, seq_len, head_dim]
+            k = past_key_values.key_cache[li]
+            v = past_key_values.value_cache[li]
             seq_len = k.shape[2]
             if seq_len > self.max_seq_len:
                 raise RuntimeError(


### PR DESCRIPTION
Two API changes in transformers 5.x break faster-qwen3-tts when installed alongside transformers >=5.0.

**1. \StaticLayer.lazy_initialization\ gained a required \alue_states\ argument**

transformers 4.x signature: \lazy_initialization(self, key_states)\
transformers 5.x signature: \lazy_initialization(self, key_states, value_states)\

Both \	alker_graph.py\ and \predictor_graph.py\ call \layer.lazy_initialization(dummy_k)\ with only one argument, which raises \TypeError\ on transformers 5.x.

Fix: pass the dummy tensor twice — \lazy_initialization(dummy_k, dummy_k)\.

**2. \DynamicCache.__getitem__\ was removed**

transformers 4.x: \DynamicCache\ supported subscript access \cache[layer_idx]\ returning \(keys, values)\.
transformers 5.x: Subscript access was removed. The cache now exposes \key_cache\ and \alue_cache\ lists directly.

\	alker_graph.py:prefill_kv\ uses \past_key_values[li]\ which raises \TypeError\ on transformers 5.x.

Fix: use \past_key_values.key_cache[li]\ and \past_key_values.value_cache[li]\ explicitly.
