### PR TITLE
docs(setup): update Blackwell guidance to cu128

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ pip install faster-qwen3-tts
 
 **PyTorch compatibility note:** CUDA-graph capture in the fast path is not reliable on `torch<=2.5.0` for this project (capture can fail with "operation not permitted when stream is capturing"). We validated `2.5.1+` as working and set that as the minimum supported version.
 
+**Blackwell note:** RTX 50xx / Blackwell GPUs need CUDA 12.8 PyTorch wheels. If the default setup fails on those cards, install a `cu128` PyTorch build (PyTorch 2.7+).
+
 ## Quick Start
 
 ### Python

--- a/WINDOWS_SETUP_GUIDE.md
+++ b/WINDOWS_SETUP_GUIDE.md
@@ -63,8 +63,9 @@ If `setup_windows.bat` warns that CUDA is not available:
 2. Run `nvidia-smi` to check CUDA support.
 3. You may need to manually install the CUDA version of PyTorch:
    ```cmd
-   .venv\Scripts\pip install \"torch>=2.5.1\" --index-url https://download.pytorch.org/whl/cu124
+   .venv\Scripts\pip install \"torch>=2.7.0\" --index-url https://download.pytorch.org/whl/cu128
    ```
+4. RTX 50xx / Blackwell GPUs need CUDA 12.8 PyTorch wheels.
 
 ### Python Not Found
 Ensure Python 3.10 or later is installed and added to your system PATH.

--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,8 @@ fi
 .venv/bin/python -c "import torch; assert torch.cuda.is_available(), 'CUDA not available'; print(f'PyTorch {torch.__version__}, CUDA {torch.version.cuda}, GPU: {torch.cuda.get_device_name(0)}')" || {
     echo ""
     echo "WARNING: CUDA not available. You may need to install a CUDA-enabled PyTorch wheel."
-    echo "  uv pip install torch --index-url https://download.pytorch.org/whl/cu124 --python .venv/bin/python"
+    echo "  uv pip install torch --index-url https://download.pytorch.org/whl/cu128 --python .venv/bin/python"
+    echo "  Note: RTX 50xx / Blackwell GPUs need CUDA 12.8 wheels (PyTorch 2.7+)."
 }
 
 # Pre-download models to HuggingFace cache

--- a/setup_windows.bat
+++ b/setup_windows.bat
@@ -36,7 +36,7 @@ if exist ".venv\Scripts\python.exe" (
     if !HAS_UV! equ 1 (
         uv venv .venv --python 3.10
         echo Installing PyTorch with CUDA support...
-        uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124 --python .venv\Scripts\python.exe
+        uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 --python .venv\Scripts\python.exe
         uv pip install -e . --python .venv\Scripts\python.exe
         
         echo Attempting to install flash-attn ^(optional^)...
@@ -46,7 +46,7 @@ if exist ".venv\Scripts\python.exe" (
         call .venv\Scripts\activate.bat
         python -m pip install --upgrade pip
         echo Installing PyTorch with CUDA support...
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
         pip install -e .
         
         echo Attempting to install flash-attn ^(optional^)...
@@ -60,7 +60,8 @@ echo.
 .venv\Scripts\python.exe -c "import torch; assert torch.cuda.is_available(), 'CUDA not available'; print(f'PyTorch {torch.__version__}, CUDA {torch.version.cuda}, GPU: {torch.cuda.get_device_name(0)}')" || (
     echo.
     echo WARNING: CUDA not available. You may need to install a CUDA-enabled PyTorch wheel.
-    echo   .venv\Scripts\pip install torch --index-url https://download.pytorch.org/whl/cu124
+    echo   .venv\Scripts\pip install torch --index-url https://download.pytorch.org/whl/cu128
+    echo   Note: RTX 50xx / Blackwell GPUs need CUDA 12.8 wheels (PyTorch 2.7+).
 )
 
 REM Pre-download models to HuggingFace cache


### PR DESCRIPTION
## Summary
- update Windows setup to install `cu128` PyTorch wheels instead of `cu124`
- update the Linux fallback hint to point Blackwell users at CUDA 12.8 wheels
- document the Blackwell / RTX 50xx requirement in the Windows guide and README

Closes #66.

## Notes
- this keeps the package minimum at `torch>=2.5.1`; the change is limited to setup/docs guidance for Blackwell-class GPUs
- no runtime code changes

## Validation
- verified all stale `cu124` references in setup/docs touched by this issue
- no tests run; docs/setup-only change