### PR TITLE
Fix PyPI license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0,<69", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -11,7 +11,8 @@ name = "faster-qwen3-tts"
 version = "0.2.5"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Andres Marafioti" }]
 keywords = ["tts", "qwen", "cuda", "cudagraph", "streaming"]
 classifiers = [


### PR DESCRIPTION
## What changed

- updated the build backend requirement to `setuptools>=77.0.0`
- switched the package metadata to the current PEP 639 form with `license = "MIT"` and `license-files = ["LICENSE"]`

## Why

PyPI rejected the 0.2.5 wheel with:

`license-file introduced in metadata version 2.4, not 2.1`

The previous build emitted `License-File: LICENSE` while still labeling the distribution metadata as `2.1`. Newer setuptools emits consistent `2.4` metadata for this configuration, which PyPI accepts.

## Validation

- `uv build --no-sources`
- inspected the rebuilt wheel and sdist metadata
- confirmed both now contain:
  - `Metadata-Version: 2.4`
  - `License-Expression: MIT`
  - `License-File: LICENSE`
