### PR TITLE
Add opus (Ogg Opus) response_format support

### DIFF
--- a/examples/openai_server.py
+++ b/examples/openai_server.py
@@ -5,6 +5,9 @@ OpenAI-compatible TTS API server for faster-qwen3-tts.
 Exposes POST /v1/audio/speech compatible with OpenAI's TTS API, enabling
 integration with OpenWebUI, llama-swap, and other OpenAI-compatible clients.
 
+Supported `response_format` values: wav, pcm, mp3, opus.
+(Upstream ships wav/pcm/mp3; this fork adds Ogg Opus via pydub+ffmpeg.)
+
 Usage:
     pip install "faster-qwen3-tts[demo]"
 
@@ -79,7 +82,7 @@ class SpeechRequest(BaseModel):
     model: str = "tts-1"
     input: str
     voice: str = "alloy"
-    response_format: str = "wav"  # wav | pcm | mp3
+    response_format: str = "wav"  # wav | pcm | mp3 | opus
     speed: float = 1.0           # accepted but not yet applied
 
 
@@ -118,23 +121,41 @@ def _to_wav_bytes(pcm: np.ndarray, sample_rate: int) -> bytes:
     return _wav_header(sample_rate, len(raw)) + raw
 
 
-def _to_mp3_bytes(pcm: np.ndarray, sample_rate: int) -> bytes:
-    """Convert float32 numpy array to MP3 bytes (requires pydub + ffmpeg)."""
+def _pcm_to_audiosegment(pcm: np.ndarray, sample_rate: int, fmt: str):
+    """Shared setup for pydub-based encoders (mp3, opus)."""
     try:
         from pydub import AudioSegment
     except ImportError:
         raise HTTPException(
             status_code=400,
-            detail="response_format='mp3' requires pydub: pip install pydub",
+            detail=f"response_format={fmt!r} requires pydub: pip install pydub",
         )
-    segment = AudioSegment(
+    return AudioSegment(
         _to_pcm16(pcm),
         frame_rate=sample_rate,
         sample_width=2,
         channels=1,
     )
+
+
+def _to_mp3_bytes(pcm: np.ndarray, sample_rate: int) -> bytes:
+    """Convert float32 numpy array to MP3 bytes (requires pydub + ffmpeg)."""
+    segment = _pcm_to_audiosegment(pcm, sample_rate, "mp3")
     buf = io.BytesIO()
     segment.export(buf, format="mp3")
+    return buf.getvalue()
+
+
+def _to_opus_bytes(pcm: np.ndarray, sample_rate: int) -> bytes:
+    """Convert float32 numpy array to OGG/Opus bytes (requires pydub + ffmpeg).
+
+    Opus's preferred sample rates are 8/12/16/24/48 kHz; the model already
+    emits 24 kHz so no resample is needed. Output is an Ogg-Opus container
+    (`audio/ogg; codecs=opus`), which is the most widely compatible form.
+    """
+    segment = _pcm_to_audiosegment(pcm, sample_rate, "opus")
+    buf = io.BytesIO()
+    segment.export(buf, format="opus")
     return buf.getvalue()
 
 
@@ -230,16 +251,19 @@ async def create_speech(req: SpeechRequest):
         "wav": "audio/wav",
         "pcm": "audio/pcm",
         "mp3": "audio/mpeg",
+        "opus": "audio/ogg",
     }
     if fmt not in _CONTENT_TYPES:
         raise HTTPException(
             status_code=400,
-            detail=f"response_format {fmt!r} not supported. Use: wav, pcm, mp3",
+            detail=f"response_format {fmt!r} not supported. Use: wav, pcm, mp3, opus",
         )
     content_type = _CONTENT_TYPES[fmt]
 
-    # --- MP3: generate all audio, then encode (non-streaming) ---
-    if fmt == "mp3":
+    # --- MP3 / Opus: generate all audio, then encode (non-streaming).
+    # Compressed codecs need the full PCM before they can produce a valid
+    # container, so these paths share the same generate-then-encode shape.
+    if fmt in ("mp3", "opus"):
         loop = asyncio.get_event_loop()
 
         def _generate():
@@ -253,7 +277,8 @@ async def create_speech(req: SpeechRequest):
 
         audio_arrays, sr = await loop.run_in_executor(None, _generate)
         audio = audio_arrays[0] if audio_arrays else np.zeros(1, dtype=np.float32)
-        return Response(content=_to_mp3_bytes(audio, sr), media_type=content_type)
+        encoder = _to_mp3_bytes if fmt == "mp3" else _to_opus_bytes
+        return Response(content=encoder(audio, sr), media_type=content_type)
 
     # --- WAV / PCM: stream chunks as they are generated ---
     async def audio_stream():


### PR DESCRIPTION
## Summary

`examples/openai_server.py` currently accepts `response_format` values of `wav`, `pcm`, and `mp3`. This PR adds `opus` — Ogg Opus encoded audio, which is what OpenAI's actual TTS API uses for its `response_format: "opus"` and what many downstream apps (OpenWebUI, custom clients, etc.) default to. My concrete use case was integrating this server behind an app that hard-codes the Opus format.

## Implementation

Minimal, parallels the existing `mp3` path:

- Factor out a shared `_pcm_to_audiosegment()` helper so the pydub import + error-message are DRY between `mp3` and the new `opus` path.
- New `_to_opus_bytes()` encoder calls `AudioSegment.export(format="opus")`, producing an Ogg-Opus container at the model's native 24 kHz (one of Opus's preferred sample rates, so no resample needed).
- `_CONTENT_TYPES` map gains `"opus": "audio/ogg"`.
- `create_speech()`'s non-streaming branch now handles both `mp3` and `opus` via an `encoder` dispatch — compressed containers need the full PCM before a valid file can be emitted, so these two paths naturally share the generate-then-encode shape.
- 400 error message and the `SpeechRequest.response_format` docstring both list `opus` in the allowed set.

Total diff: +34 / -9 in one file.

## Dependencies

Same as the existing `mp3` path: `pydub` plus an `ffmpeg` build with `libopus` (the Debian/Ubuntu default). Upstream's `[demo]` extras don't currently install `pydub`, so `mp3` and `opus` users both need to `pip install pydub` today. I left that alone to keep this PR scoped to the feature — happy to fold in a `pydub` pin under `[demo]` if you'd prefer it in a single PR.

## Verification

Built and ran in a Dockerized deployment on an RTX 4080:

- `POST /v1/audio/speech` with `response_format: "opus"` → HTTP 200, `Content-Type: audio/ogg`, ~22 KB for a 4-second phrase
- `file` verdict on the response body: `Ogg data, Opus audio, version 0.1, mono, 24000 Hz`
- Warm-path round trip: ~0.7 s after CUDA graph capture
- `wav`, `pcm`, `mp3` paths unchanged — verified by rerunning existing round-trip tests

Happy to iterate on naming (e.g. accepting `ogg` as an alias), the pydub dependency question, or anything else you'd prefer. Marking as draft until you've had a chance to weigh in.