### PR TITLE
Add runtime voice management API (GET/POST/DELETE /v1/audio/voices)

### DIFF
--- a/examples/openai_server.py
+++ b/examples/openai_server.py
@@ -191,7 +191,13 @@ def _validate_voice_name(name: str) -> None:
 
 
 def _persist_voices_unlocked() -> None:
-    """Rewrite voices.json atomically. Caller must hold _voices_lock."""
+    """Rewrite voices.json atomically. Caller must hold _voices_lock.
+
+    Note on bind mounts: atomic rename only works when voices.json lives
+    inside a *directory* bind mount, not a file bind mount. The latter
+    binds the kernel mountpoint to the file itself, and os.replace()
+    across it returns EBUSY. Mount the parent directory instead.
+    """
     if voices_json_path is None:
         # Server wasn't started with --voices; nothing to persist.
         return
@@ -206,6 +212,11 @@ def _persist_voices_unlocked() -> None:
         with os.fdopen(fd, "w") as f:
             json.dump(voices, f, indent=2, ensure_ascii=False)
             f.write("\n")
+        # mkstemp creates files with secure 0600 perms. When voices.json
+        # is on a host bind mount the server owner differs from the host
+        # user, so widen to 0644 so the host user (and any sidecar tools
+        # like add_voice.py) can still read the file.
+        os.chmod(tmp_path, 0o644)
         os.replace(tmp_path, str(voices_json_path))
     except Exception:
         try:

--- a/examples/openai_server.py
+++ b/examples/openai_server.py
@@ -41,15 +41,18 @@ import json
 import logging
 import os
 import queue
+import re
 import struct
 import sys
+import tempfile
 import threading
+from pathlib import Path
 from typing import AsyncGenerator, Optional
 
 import numpy as np
 import torch
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 
@@ -69,6 +72,18 @@ voices: dict = {}
 default_voice: Optional[str] = None
 SAMPLE_RATE = 24000  # updated once the model loads
 _model_lock = threading.Lock()  # prevent concurrent GPU inference
+
+# Voice management state. Populated by main() when --voices is used.
+# voices_json_path is the source-of-truth JSON file on disk that we
+# atomically rewrite on upload / delete. voice_samples_dir is where
+# uploaded WAVs live.
+voices_json_path: Optional[Path] = None
+voice_samples_dir: Optional[Path] = None
+_voices_lock = threading.Lock()  # protect voices dict + voices.json file
+
+# Voice names must be filesystem-safe and URL-safe. Matches a-z, 0-9,
+# underscore, hyphen — no dots, slashes, or whitespace.
+_VOICE_NAME_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 # ---------------------------------------------------------------------------
 # Request / response models
@@ -163,6 +178,43 @@ def resolve_voice(voice_name: str) -> dict:
     )
 
 
+def _validate_voice_name(name: str) -> None:
+    """Raise 400 if the voice name is empty or unsafe for the filesystem."""
+    if not name or not _VOICE_NAME_RE.match(name):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Invalid voice name. Use only letters, digits, underscore, "
+                "and hyphen (no dots, slashes, or whitespace)."
+            ),
+        )
+
+
+def _persist_voices_unlocked() -> None:
+    """Rewrite voices.json atomically. Caller must hold _voices_lock."""
+    if voices_json_path is None:
+        # Server wasn't started with --voices; nothing to persist.
+        return
+    parent = voices_json_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    # Write to a sibling temp file then atomically rename so a crash
+    # mid-write can't corrupt voices.json.
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".voices-", suffix=".json.tmp", dir=str(parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(voices, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp_path, str(voices_json_path))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 # ---------------------------------------------------------------------------
 # Streaming helper: run sync generator in a background thread
 # ---------------------------------------------------------------------------
@@ -214,6 +266,146 @@ async def _stream_chunks(voice_cfg: dict, text: str) -> AsyncGenerator[bytes, No
 @app.get("/health")
 async def health():
     return {"status": "ok", "model_loaded": tts_model is not None}
+
+
+# ---------------------------------------------------------------------------
+# Voice management API
+#
+# Mirrors the shape of vllm-omni's /v1/audio/voices endpoints so existing
+# clients can drop in unchanged. Uploaded voices are written to
+# voice_samples_dir (next to voices.json by default) and the voices.json
+# file is rewritten atomically on every mutation.
+#
+# Requires --voices <file> (or QWEN_TTS_VOICES); when using --ref-audio
+# in single-voice mode there is no persistent registry to mutate.
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/audio/voices")
+async def list_voices():
+    with _voices_lock:
+        names = sorted(voices.keys())
+        details = [
+            {
+                "name": name,
+                "ref_text": cfg.get("ref_text", ""),
+                "language": cfg.get("language", "Auto"),
+                "ref_audio": cfg.get("ref_audio", ""),
+            }
+            for name, cfg in voices.items()
+        ]
+    return {"voices": names, "uploaded_voices": details}
+
+
+@app.post("/v1/audio/voices")
+async def upload_voice(
+    audio_sample: UploadFile = File(...),
+    name: str = Form(...),
+    ref_text: str = Form(""),
+    language: str = Form("English"),
+    consent: Optional[str] = Form(None),  # accepted for vllm-omni compat; unused
+):
+    if voices_json_path is None or voice_samples_dir is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Server was started without --voices, so runtime voice "
+                "management is disabled. Restart with --voices <file> to "
+                "enable upload/delete."
+            ),
+        )
+    _validate_voice_name(name)
+    if consent:
+        logger.info("Voice upload %r received consent field: %r", name, consent)
+
+    content = await audio_sample.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="audio_sample is empty")
+
+    dest = voice_samples_dir / f"{name}.wav"
+
+    with _voices_lock:
+        voice_samples_dir.mkdir(parents=True, exist_ok=True)
+        existed = name in voices
+        try:
+            dest.write_bytes(content)
+        except OSError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to write reference audio to {dest}: {exc}",
+            )
+        voices[name] = {
+            "ref_audio": str(dest),
+            "ref_text": ref_text,
+            "language": language,
+        }
+        try:
+            _persist_voices_unlocked()
+        except OSError as exc:
+            # Roll back the in-memory change so state stays consistent.
+            if existed:
+                logger.exception("voices.json write failed; in-memory entry kept")
+            else:
+                voices.pop(name, None)
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to persist voices.json: {exc}",
+            )
+
+        global default_voice
+        if default_voice is None or default_voice not in voices:
+            default_voice = name
+
+    return {
+        "name": name,
+        "status": "replaced" if existed else "created",
+        "ref_audio": str(dest),
+        "file_size": len(content),
+    }
+
+
+@app.delete("/v1/audio/voices/{name}")
+async def delete_voice(name: str):
+    if voices_json_path is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Server was started without --voices; nothing to delete.",
+        )
+    _validate_voice_name(name)
+
+    with _voices_lock:
+        if name not in voices:
+            raise HTTPException(
+                status_code=404, detail=f"Voice {name!r} not found"
+            )
+        entry = voices.pop(name)
+        try:
+            _persist_voices_unlocked()
+        except OSError as exc:
+            voices[name] = entry  # roll back
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to persist voices.json: {exc}",
+            )
+
+        # Best-effort delete of the reference WAV. Only remove files that
+        # live under our managed voice_samples_dir, so we never accidentally
+        # unlink a WAV the user pointed at via an absolute path in voices.json.
+        ref_audio = entry.get("ref_audio", "")
+        if ref_audio and voice_samples_dir is not None:
+            try:
+                ref_path = Path(ref_audio).resolve()
+                vsd = voice_samples_dir.resolve()
+                if ref_path.is_relative_to(vsd) and ref_path.exists():
+                    ref_path.unlink()
+            except (OSError, ValueError) as exc:
+                logger.warning("Failed to delete %s: %s", ref_audio, exc)
+
+        global default_voice
+        if default_voice == name:
+            default_voice = next(iter(voices), None)
+
+    return {"name": name, "status": "deleted"}
 
 
 @app.post("/v1/audio/speech")
@@ -303,6 +495,15 @@ def _parse_args():
         default=os.environ.get("QWEN_TTS_LANGUAGE", "Auto"),
         help="Target language (English, French, Auto, …) when --voices is not used",
     )
+    p.add_argument(
+        "--voice-samples-dir",
+        default=os.environ.get("QWEN_TTS_VOICE_SAMPLES_DIR"),
+        metavar="DIR",
+        help=(
+            "Directory where uploaded reference WAVs are written via "
+            "POST /v1/audio/voices. Defaults to <dir of voices.json>/voice_samples."
+        ),
+    )
     p.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
     p.add_argument("--port", type=int, default=8000, help="Bind port (default: 8000)")
     p.add_argument("--device", default="cuda", help="Torch device (default: cuda)")
@@ -311,6 +512,7 @@ def _parse_args():
 
 def main():
     global tts_model, voices, default_voice, SAMPLE_RATE
+    global voices_json_path, voice_samples_dir
 
     args = _parse_args()
 
@@ -318,8 +520,20 @@ def main():
     if args.voices:
         with open(args.voices) as f:
             voices = json.load(f)
-        default_voice = next(iter(voices))
-        logger.info("Loaded %d voice(s) from %s", len(voices), args.voices)
+        default_voice = next(iter(voices)) if voices else None
+        voices_json_path = Path(args.voices).resolve()
+        # Uploaded WAVs live next to voices.json by default.
+        if args.voice_samples_dir:
+            voice_samples_dir = Path(args.voice_samples_dir).resolve()
+        else:
+            voice_samples_dir = voices_json_path.parent / "voice_samples"
+        voice_samples_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "Loaded %d voice(s) from %s (samples dir: %s)",
+            len(voices),
+            args.voices,
+            voice_samples_dir,
+        )
     elif args.ref_audio:
         voices = {
             "default": {


### PR DESCRIPTION
## Summary

`examples/openai_server.py` reads `voices.json` once at startup and has no way to add, replace, or remove voices without a process restart. This PR adds runtime voice management HTTP endpoints:

```
GET    /v1/audio/voices               → {"voices": [...], "uploaded_voices": [...]}
POST   /v1/audio/voices  (multipart)  → {"name", "status": "created"|"replaced", ...}
DELETE /v1/audio/voices/{name}        → {"name", "status": "deleted"}
```

The response shapes mirror `vllm-omni`'s `/v1/audio/voices` API so existing clients written against that server drop in unchanged. (My personal motivation was migrating off `vllm-omni` without touching downstream app code.)

Totally understand if runtime voice management isn't in scope for what `examples/openai_server.py` is meant to be — happy to move it into a separate example file, or close the PR entirely if you'd rather keep the example minimal. Marking as draft for that reason.

## POST schema (multipart/form-data)

| Field | Required | Notes |
|---|---|---|
| `audio_sample` | yes | The reference WAV |
| `name` | yes | Validated against `^[A-Za-z0-9_-]+$` — filesystem- and URL-safe |
| `ref_text` | no | Exact transcript of the clip; meaningful impact on clone quality |
| `language` | no | Defaults to `"English"` |
| `consent` | no | Accepted and logged but not persisted — there purely for vllm-omni client compatibility |

## Design notes

- **No model-state impact.** Uploaded voices are usable on the very next request because `generate_voice_clone_streaming()` already reads `ref_audio` as a per-call path — nothing is pre-loaded onto the GPU. Adding a voice is purely a dict + disk update.
- **Independent lock.** New module-level `_voices_lock: threading.Lock` guards the `voices` dict and `voices.json` file. Separate from `_model_lock` so voice edits never block inference in progress.
- **Atomic writes.** `voices.json` is rewritten via `tempfile.mkstemp() + os.replace()` so a crash mid-write can't corrupt the registry. In-memory state rolls back on disk failure so the dict and file stay consistent.
- **New CLI flag.** `--voice-samples-dir` (env `QWEN_TTS_VOICE_SAMPLES_DIR`) lets deployments control where uploaded WAVs are written. Defaults to `<dir of voices.json>/voice_samples`, which matches how most deployments already lay things out — no config change is needed.
- **Delete safety.** DELETE only unlinks reference WAVs that live under the managed `voice_samples_dir`, so it won't accidentally remove user-provided absolute paths dropped into `voices.json` by hand.
- **Mode 0644 on `voices.json` after atomic write.** `tempfile.mkstemp()` defaults to 0600, which locks out host users on Docker bind mounts. Explicit `os.chmod` after rename widens to 0644 (matches the default umask'd perms on WAV files from `Path.write_bytes`). This is the second commit in the PR, kept separate for clarity — happy to squash on merge.
- **`--ref-audio` single-voice mode unaffected.** Voice management endpoints return 503 with an explanatory message in that mode since there's no persistent registry to mutate.

## Gotcha worth calling out: Docker bind mounts

Atomic rename only works when `voices.json` lives inside a **directory** bind mount, not a single-file bind mount. The latter binds the kernel mountpoint to the file itself and `os.replace()` across it returns `EBUSY`. There's a docstring note about this in `_persist_voices_unlocked()`, but it's a real footgun for downstream Docker deployments. Worth mentioning in any deployment docs.

## Verification

Full round-trip against a Dockerized deployment on an RTX 4080:

- GET baseline list → 10 voices
- POST upload `stallman_test` with `ref_text` and `language` → 200, WAV written to `<voice_samples_dir>/stallman_test.wav`, `voices.json` atomically rewritten
- GET list → 11, `stallman_test` present with all metadata fields
- Host user reads `voices.json` without sudo (mode 0644 ✓)
- POST `/v1/audio/speech` with `voice: "stallman_test"` → 200, valid WAV generated via the newly uploaded voice
- DELETE `/v1/audio/voices/stallman_test` → 200, file removed from voice_samples_dir
- DELETE on non-existent name → 404
- DELETE on invalid name (`bad..name`) → 400
- GET list → back to 10

## Compatibility

- **Additive for `--voices` mode.** No existing behavior changes; the endpoints are new.
- **No-op for `--ref-audio` mode.** Voice endpoints return 503 with an explanatory message.
- **`python-multipart`** is already pulled in via `fastapi[standard]` / `uvicorn[standard]` from the existing `[demo]` extras for `UploadFile`/`Form` types — no new deps.
- Two commits (feature + perms fix), easy to squash if you prefer a single-commit PR.