### PR TITLE
Allow non_streaming_mode=None to preserve upstream defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ The 12 Hz codec uses a causal `chunked_decode`: each frame is reconstructed usin
 ### Text input streaming vs Non-streaming quality
 
 The original Qwen3TTS implementation supports two mode of generation. It either takes the full input text and prepares the utterance, or it feeds the text progressively. This is the `non_streaming_mode` parameter in the generation methods. The name is maintained from the Qwen3TTS implementation, but I understand it might bring some headaches since here we also have general audio output streaming.
-`generate_voice_clone` now defaults to `non_streaming_mode=False` to match upstream step-by-step text feeding during decode.
-`generate_voice_clone_streaming` also defaults to `non_streaming_mode=False`. Set either method to `True` to pre-fill the full target text before decode for the old behavior.
-`generate_custom_voice`, `generate_custom_voice_streaming`, `generate_voice_design`, and `generate_voice_design_streaming` default to `non_streaming_mode=True` to match the upstream CustomVoice and VoiceDesign defaults.
+The public API uses `non_streaming_mode=None` as a sentinel, which preserves each method's upstream default unless you override it explicitly.
+`generate_voice_clone` and `generate_voice_clone_streaming` resolve `None` to `False`, matching upstream step-by-step text feeding during decode.
+`generate_custom_voice`, `generate_custom_voice_streaming`, `generate_voice_design`, and `generate_voice_design_streaming` resolve `None` to `True`, matching the upstream CustomVoice and VoiceDesign defaults.
 
 **Performance impact (RTX 4090, 1.7B, ICL, chunk_size=8):** TTFA is unchanged (≈159ms ± 1ms), and RTF is effectively the same (nsm=False: 4.87 ± 0.01, nsm=True: 4.85 ± 0.01).
 

--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -3,5 +3,5 @@ faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 """
 from .model import FasterQwen3TTS
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __all__ = ["FasterQwen3TTS"]

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -80,6 +80,15 @@ class FasterQwen3TTS:
             return 24000
 
         return int(sample_rate)
+
+    @staticmethod
+    def _resolve_non_streaming_mode(
+        non_streaming_mode: Optional[bool],
+        *,
+        default: bool,
+    ) -> bool:
+        """Treat None as the method-specific upstream default."""
+        return default if non_streaming_mode is None else non_streaming_mode
         
     @classmethod
     def from_pretrained(
@@ -739,7 +748,7 @@ class FasterQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         xvec_only: bool = False,
-        non_streaming_mode: bool = False,
+        non_streaming_mode: Optional[bool] = None,
         append_silence: bool = True,
         instruct: Optional[str] = None,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
@@ -763,8 +772,9 @@ class FasterQwen3TTS:
                 This prevents phoneme bleed-through from the reference and allows clean
                 language switching. Default False to match upstream ICL behavior
                 (reference audio in context).
-            non_streaming_mode: Match upstream text-feeding layout. Default False to match
-                upstream step-by-step text feeding during decode.
+            non_streaming_mode: Match upstream text-feeding layout. When None, use the
+                upstream voice-cloning default (False, step-by-step text feeding during
+                decode). Set True to prefill the full target text before decode.
             voice_clone_prompt: Optional precomputed voice clone prompt dict. When provided,
                 `xvec_only` is ignored and prompt extraction from `ref_audio` is skipped.
                 This path supports x-vector-only prompts (`ref_spk_embedding` only)
@@ -778,6 +788,11 @@ class FasterQwen3TTS:
             Tuple of ([audio_waveform], sample_rate)
         """
         from .generate import fast_generate
+
+        non_streaming_mode = self._resolve_non_streaming_mode(
+            non_streaming_mode,
+            default=False,
+        )
 
         m, talker, config, tie, tam, tth, tpe, ref_codes = self._prepare_generation(
             text=text,
@@ -865,7 +880,7 @@ class FasterQwen3TTS:
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
         xvec_only: bool = False,
-        non_streaming_mode: bool = False,
+        non_streaming_mode: Optional[bool] = None,
         append_silence: bool = True,
         parity_mode: bool = False,
         instruct: Optional[str] = None,
@@ -894,8 +909,9 @@ class FasterQwen3TTS:
                 This prevents phoneme bleed-through from the reference and allows clean
                 language switching. Default False to match upstream ICL behavior
                 (reference audio in context).
-            non_streaming_mode: Default False to match upstream text feeding during decode.
-                Set to True to prefill the full target text before streaming decode.
+            non_streaming_mode: When None, use the upstream voice-cloning default
+                (False, step-by-step text feeding during decode). Set to True to
+                prefill the full target text before streaming decode.
             parity_mode: When True, disables CUDA graphs and uses dynamic cache streaming.
             voice_clone_prompt: Optional precomputed voice clone prompt dict. When provided,
                 `xvec_only` is ignored and prompt extraction from `ref_audio` is skipped.
@@ -910,6 +926,11 @@ class FasterQwen3TTS:
             Tuple of (audio_chunk_numpy, sample_rate, timing_dict)
         """
         from .streaming import fast_generate_streaming, parity_generate_streaming
+
+        non_streaming_mode = self._resolve_non_streaming_mode(
+            non_streaming_mode,
+            default=False,
+        )
 
         m, talker, config, tie, tam, tth, tpe, ref_codes = self._prepare_generation(
             text=text,
@@ -1023,7 +1044,7 @@ class FasterQwen3TTS:
         speaker: str,
         language: str,
         instruct: Optional[str] = None,
-        non_streaming_mode: bool = True,
+        non_streaming_mode: Optional[bool] = None,
         max_new_tokens: int = 2048,
         min_new_tokens: int = 2,
         temperature: float = 0.9,
@@ -1037,6 +1058,11 @@ class FasterQwen3TTS:
 
         self.model._validate_languages([language])
         self.model._validate_speakers([speaker])
+
+        non_streaming_mode = self._resolve_non_streaming_mode(
+            non_streaming_mode,
+            default=True,
+        )
 
         if self.model.model.tts_model_size in "0b6":
             instruct = None
@@ -1102,7 +1128,7 @@ class FasterQwen3TTS:
         speaker: str,
         language: str,
         instruct: Optional[str] = None,
-        non_streaming_mode: bool = True,
+        non_streaming_mode: Optional[bool] = None,
         max_new_tokens: int = 2048,
         min_new_tokens: int = 2,
         temperature: float = 0.9,
@@ -1117,6 +1143,11 @@ class FasterQwen3TTS:
 
         self.model._validate_languages([language])
         self.model._validate_speakers([speaker])
+
+        non_streaming_mode = self._resolve_non_streaming_mode(
+            non_streaming_mode,
+            default=True,
+        )
 
         if self.model.model.tts_model_size in "0b6":
             instruct = None
@@ -1201,7 +1232,7 @@ class FasterQwen3TTS:
         text: str,
         instruct: str,
         language: str,
-        non_streaming_mode: bool = True,
+        non_streaming_mode: Optional[bool] = None,
         max_new_tokens: int = 2048,
         min_new_tokens: int = 2,
         temperature: float = 0.9,
@@ -1214,6 +1245,11 @@ class FasterQwen3TTS:
             raise ValueError("Loaded model does not support voice design generation")
 
         self.model._validate_languages([language])
+
+        non_streaming_mode = self._resolve_non_streaming_mode(
+            non_streaming_mode,
+            default=True,
+        )
 
         from .generate import fast_generate
 
@@ -1275,7 +1311,7 @@ class FasterQwen3TTS:
         text: str,
         instruct: str,
         language: str,
-        non_streaming_mode: bool = True,
+        non_streaming_mode: Optional[bool] = None,
         max_new_tokens: int = 2048,
         min_new_tokens: int = 2,
         temperature: float = 0.9,
@@ -1289,6 +1325,11 @@ class FasterQwen3TTS:
             raise ValueError("Loaded model does not support voice design generation")
 
         self.model._validate_languages([language])
+
+        non_streaming_mode = self._resolve_non_streaming_mode(
+            non_streaming_mode,
+            default=True,
+        )
 
         from .streaming import fast_generate_streaming
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["faster_qwen3_tts*"]
 
 [project]
 name = "faster-qwen3-tts"
-version = "0.2.5"
+version = "0.2.6"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -16,11 +16,15 @@ def _build_dummy_model():
     base.model = types.SimpleNamespace(
         talker=types.SimpleNamespace(rope_deltas=None),
         config=types.SimpleNamespace(talker_config=types.SimpleNamespace()),
+        tts_model_size="1b7",
+        tts_model_type="base",
     )
     base._build_assistant_text = lambda text: text
     base._build_ref_text = lambda text: text
     base._build_instruct_text = lambda text: text
     base._tokenize_texts = lambda _texts: [torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], dtype=torch.long)]
+    base._validate_languages = lambda _languages: None
+    base._validate_speakers = lambda _speakers: None
 
     def _fail(*_args, **_kwargs):
         raise AssertionError("create_voice_clone_prompt should not be called when voice_clone_prompt is provided")
@@ -60,21 +64,132 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     assert list(sig_clone.parameters)[-1] == "voice_clone_prompt"
     assert list(sig_stream.parameters)[-1] == "voice_clone_prompt"
     assert sig_clone.parameters["xvec_only"].default is False
-    assert sig_clone.parameters["non_streaming_mode"].default is False
+    assert sig_clone.parameters["non_streaming_mode"].default is None
     assert sig_stream.parameters["xvec_only"].default is False
-    assert sig_stream.parameters["non_streaming_mode"].default is False
+    assert sig_stream.parameters["non_streaming_mode"].default is None
 
 
-def test_public_api_matches_upstream_non_streaming_defaults():
+def test_public_api_uses_none_sentinel_for_non_streaming_overrides():
     sig_custom = inspect.signature(FasterQwen3TTS.generate_custom_voice)
     sig_custom_stream = inspect.signature(FasterQwen3TTS.generate_custom_voice_streaming)
     sig_design = inspect.signature(FasterQwen3TTS.generate_voice_design)
     sig_design_stream = inspect.signature(FasterQwen3TTS.generate_voice_design_streaming)
 
-    assert sig_custom.parameters["non_streaming_mode"].default is True
-    assert sig_custom_stream.parameters["non_streaming_mode"].default is True
-    assert sig_design.parameters["non_streaming_mode"].default is True
-    assert sig_design_stream.parameters["non_streaming_mode"].default is True
+    assert sig_custom.parameters["non_streaming_mode"].default is None
+    assert sig_custom_stream.parameters["non_streaming_mode"].default is None
+    assert sig_design.parameters["non_streaming_mode"].default is None
+    assert sig_design_stream.parameters["non_streaming_mode"].default is None
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "expected_default"),
+    [
+        ("generate_voice_clone", {"text": "hello", "language": "English"}, False),
+        ("generate_voice_clone_streaming", {"text": "hello", "language": "English"}, False),
+        (
+            "generate_custom_voice",
+            {"text": "hello", "speaker": "speaker_a", "language": "English"},
+            True,
+        ),
+        (
+            "generate_custom_voice_streaming",
+            {"text": "hello", "speaker": "speaker_a", "language": "English"},
+            True,
+        ),
+        (
+            "generate_voice_design",
+            {"text": "hello", "instruct": "bright radio voice", "language": "English"},
+            True,
+        ),
+        (
+            "generate_voice_design_streaming",
+            {"text": "hello", "instruct": "bright radio voice", "language": "English"},
+            True,
+        ),
+    ],
+)
+def test_public_generation_methods_resolve_none_to_mode_defaults(
+    monkeypatch, method_name, kwargs, expected_default
+):
+    model = _build_dummy_model()
+    captured = {}
+
+    if "custom" in method_name:
+        model.model.model.tts_model_type = "custom_voice"
+    elif "design" in method_name:
+        model.model.model.tts_model_type = "voice_design"
+
+    def _capture_clone(*_args, **inner_kwargs):
+        captured["non_streaming_mode"] = inner_kwargs["non_streaming_mode"]
+        raise RuntimeError("stop after capture")
+
+    def _capture_custom(*_args, **inner_kwargs):
+        captured["non_streaming_mode"] = inner_kwargs["non_streaming_mode"]
+        raise RuntimeError("stop after capture")
+
+    if "clone" in method_name:
+        monkeypatch.setattr(model, "_prepare_generation", _capture_clone)
+    else:
+        monkeypatch.setattr(model, "_prepare_generation_custom", _capture_custom)
+
+    with pytest.raises(RuntimeError, match="stop after capture"):
+        result = getattr(model, method_name)(non_streaming_mode=None, **kwargs)
+        if method_name.endswith("_streaming"):
+            next(result)
+
+    assert captured["non_streaming_mode"] is expected_default
+
+
+@pytest.mark.parametrize("override", [False, True])
+@pytest.mark.parametrize(
+    ("method_name", "kwargs"),
+    [
+        ("generate_voice_clone", {"text": "hello", "language": "English"}),
+        ("generate_voice_clone_streaming", {"text": "hello", "language": "English"}),
+        (
+            "generate_custom_voice",
+            {"text": "hello", "speaker": "speaker_a", "language": "English"},
+        ),
+        (
+            "generate_custom_voice_streaming",
+            {"text": "hello", "speaker": "speaker_a", "language": "English"},
+        ),
+        (
+            "generate_voice_design",
+            {"text": "hello", "instruct": "bright radio voice", "language": "English"},
+        ),
+        (
+            "generate_voice_design_streaming",
+            {"text": "hello", "instruct": "bright radio voice", "language": "English"},
+        ),
+    ],
+)
+def test_public_generation_methods_preserve_explicit_non_streaming_overrides(
+    monkeypatch, method_name, kwargs, override
+):
+    model = _build_dummy_model()
+    captured = {}
+
+    if "custom" in method_name:
+        model.model.model.tts_model_type = "custom_voice"
+    elif "design" in method_name:
+        model.model.model.tts_model_type = "voice_design"
+
+    def _capture(*_args, **inner_kwargs):
+        captured["non_streaming_mode"] = inner_kwargs["non_streaming_mode"]
+        raise RuntimeError("stop after capture")
+
+    if "clone" in method_name:
+        monkeypatch.setattr(model, "_prepare_generation", _capture)
+    else:
+        monkeypatch.setattr(model, "_prepare_generation_custom", _capture)
+
+    with pytest.raises(RuntimeError, match="stop after capture"):
+        result = getattr(model, method_name)(non_streaming_mode=override, **kwargs)
+        if method_name.endswith("_streaming"):
+            next(result)
+
+    assert captured["non_streaming_mode"] is override
 
 
 def test_prepare_generation_uses_precomputed_xvec_prompt_without_prompt_extraction():


### PR DESCRIPTION
## Summary
- change the public generation APIs to accept `non_streaming_mode: Optional[bool] = None`
- resolve `None` to each mode's upstream default at the wrapper boundary instead of forcing callers to re-encode those defaults
- bump the package version to `0.2.6` and document the sentinel behavior

## Why
The wrapper already has different upstream defaults depending on the generation mode:
- voice cloning defaults to `False`
- CustomVoice and VoiceDesign default to `True`

Using `None` as the public sentinel lets downstream callers pass an override only when they actually want one, while still preserving the existing per-mode behavior when unset.

## Validation
- `.venv/bin/python -m pytest tests/test_voice_clone_prompt_api.py`
