### PR TITLE
Add continuation state API

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,49 @@ The public API uses `non_streaming_mode=None` as a sentinel, which preserves eac
 
 **Performance impact (RTX 4090, 1.7B, ICL, chunk_size=8):** TTFA is unchanged (≈159ms ± 1ms), and RTF is effectively the same (nsm=False: 4.87 ± 0.01, nsm=True: 4.85 ± 0.01).
 
+### Continuation state
+
+All public generation methods can now return caller-owned continuation tensors and accept them again on a later request:
+
+- `generate_voice_clone`
+- `generate_voice_clone_streaming`
+- `generate_custom_voice`
+- `generate_custom_voice_streaming`
+- `generate_voice_design`
+- `generate_voice_design_streaming`
+
+Use `return_continuation_state="full"` on the first turn to capture the full talker state, then pass that state back as `continuation_state` on later turns. For streaming or long-lived sessions, request `return_continuation_state="delta"` and merge it with `apply_continuation_state_delta(...)` so the caller only appends newly generated cache rows.
+
+```python
+from faster_qwen3_tts import FasterQwen3TTS, apply_continuation_state_delta
+
+audio1, sr, info1 = model.generate_custom_voice(
+    text="The first sentence sets the rhythm.",
+    speaker="aiden",
+    language="English",
+    return_continuation_state="full",
+)
+state = info1["continuation_state"]
+
+audio2, sr, info2 = model.generate_custom_voice(
+    text="The second sentence should continue naturally.",
+    speaker="aiden",
+    language="English",
+    continuation_state=state,
+    return_continuation_state="delta",
+)
+state = apply_continuation_state_delta(state, info2["continuation_state_delta"])
+```
+
+The same API works for Base voice clone and VoiceDesign, and for both audio-output modes. Continuation states are mode-specific and must match the same model configuration and `non_streaming_mode`. If the saved state grows too close to `max_seq_len`, start a fresh session.
+When continuation metadata is returned, `info["continuation_state_status"]` reports the current `seq_len`, remaining token budget, and a warning when the session is getting close to the limit. Streaming yields the same field inside each chunk's `timing` dict.
+
+To reproduce the latency impact on follow-up turns, run `benchmarks/continuation.py`. Example:
+
+```bash
+./.venv/bin/python benchmarks/continuation.py --mode custom_voice --runs 5 --max-new-tokens 96 --chunk-size 8
+```
+
 ### Base-model instruct
 
 `instruct` is available on Base voice cloning, but treat it as experimental when used with `xvec_only=True`. In local testing and upstream-core probing, instruction-following behaved much more predictably in ICL mode (`xvec_only=False`) than in x-vector-only mode.

--- a/benchmarks/continuation.py
+++ b/benchmarks/continuation.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Benchmark fresh vs continuation follow-up turns."""
+import argparse
+import os
+import time
+
+import numpy as np
+import torch
+
+from faster_qwen3_tts import FasterQwen3TTS
+
+PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DEFAULT_FIRST = (
+    "The first sentence should establish a natural speaking rhythm and a clear vocal posture."
+)
+DEFAULT_SECOND = (
+    "The second sentence should sound like the same speaker continuing the same thought without a hard reset."
+)
+DEFAULT_REF_TEXT = (
+    "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs."
+)
+
+
+def _measure_stream_ttfa(fn, runs: int):
+    values = []
+    for _ in range(runs):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        gen = fn()
+        try:
+            next(gen)
+        finally:
+            gen.close()
+        torch.cuda.synchronize()
+        values.append((time.perf_counter() - t0) * 1000)
+    return float(np.mean(values)), float(np.std(values))
+
+
+def _measure_nonstream(fn, runs: int):
+    latencies = []
+    rtfs = []
+    for _ in range(runs):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        result = fn()
+        torch.cuda.synchronize()
+        total = time.perf_counter() - t0
+        if len(result) == 3:
+            audio_list, sr, _info = result
+        else:
+            audio_list, sr = result
+        dur = len(audio_list[0]) / sr
+        latencies.append(total * 1000)
+        rtfs.append(dur / total if total > 0 else 0.0)
+    return (
+        float(np.mean(latencies)),
+        float(np.std(latencies)),
+        float(np.mean(rtfs)),
+        float(np.std(rtfs)),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark continuation-state follow-up turns")
+    parser.add_argument("--mode", choices=["voice_clone", "custom_voice", "voice_design"], default="voice_clone")
+    parser.add_argument("--model", default=None, help="Override model id")
+    parser.add_argument("--language", default=os.environ.get("LANGUAGE", "English"))
+    parser.add_argument("--first-text", default=os.environ.get("FIRST_TEXT", DEFAULT_FIRST))
+    parser.add_argument("--second-text", default=os.environ.get("SECOND_TEXT", DEFAULT_SECOND))
+    parser.add_argument("--chunk-size", type=int, default=int(os.environ.get("CHUNK_SIZE", "8")))
+    parser.add_argument("--runs", type=int, default=int(os.environ.get("RUNS", "5")))
+    parser.add_argument("--xvec-only", action="store_true")
+    parser.add_argument("--speaker", default=os.environ.get("SPEAKER"))
+    parser.add_argument("--instruct", default=os.environ.get("INSTRUCT", "Warm, conversational, medium pace."))
+    parser.add_argument("--ref-audio", default=os.environ.get("REF_AUDIO", os.path.join(PROJECT_DIR, "ref_audio.wav")))
+    parser.add_argument("--ref-text", default=os.environ.get("REF_TEXT", DEFAULT_REF_TEXT))
+    parser.add_argument("--max-new-tokens", type=int, default=int(os.environ.get("MAX_NEW_TOKENS", "256")))
+    args = parser.parse_args()
+
+    if args.model is None:
+        if args.mode == "voice_clone":
+            args.model = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+        elif args.mode == "custom_voice":
+            args.model = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
+        else:
+            args.model = "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
+
+    print(f"Loading {args.mode}: {args.model}")
+    model = FasterQwen3TTS.from_pretrained(
+        args.model,
+        device="cuda",
+        dtype=torch.bfloat16,
+        attn_implementation="eager",
+        max_seq_len=2048,
+    )
+
+    common_kwargs = {
+        "language": args.language,
+    }
+
+    if args.mode == "voice_clone":
+        first_call = lambda **kw: model.generate_voice_clone(
+            text=args.first_text,
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            xvec_only=args.xvec_only,
+            return_continuation_state="full",
+            max_new_tokens=kw.pop("max_new_tokens", args.max_new_tokens),
+            **common_kwargs,
+            **kw,
+        )
+        fresh_nonstream = lambda: model.generate_voice_clone(
+            text=args.second_text,
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            xvec_only=args.xvec_only,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+        fresh_stream = lambda: model.generate_voice_clone_streaming(
+            text=args.second_text,
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            xvec_only=args.xvec_only,
+            chunk_size=args.chunk_size,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+    elif args.mode == "custom_voice":
+        speakers = model.model.get_supported_speakers() or []
+        if not speakers and not args.speaker:
+            raise RuntimeError("No speakers reported by model; pass --speaker explicitly")
+        speaker = args.speaker or speakers[0]
+        print(f"Using speaker: {speaker}")
+        first_call = lambda **kw: model.generate_custom_voice(
+            text=args.first_text,
+            speaker=speaker,
+            instruct=args.instruct,
+            return_continuation_state="full",
+            max_new_tokens=kw.pop("max_new_tokens", args.max_new_tokens),
+            **common_kwargs,
+            **kw,
+        )
+        fresh_nonstream = lambda: model.generate_custom_voice(
+            text=args.second_text,
+            speaker=speaker,
+            instruct=args.instruct,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+        fresh_stream = lambda: model.generate_custom_voice_streaming(
+            text=args.second_text,
+            speaker=speaker,
+            instruct=args.instruct,
+            chunk_size=args.chunk_size,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+    else:
+        first_call = lambda **kw: model.generate_voice_design(
+            text=args.first_text,
+            instruct=args.instruct,
+            return_continuation_state="full",
+            max_new_tokens=kw.pop("max_new_tokens", args.max_new_tokens),
+            **common_kwargs,
+            **kw,
+        )
+        fresh_nonstream = lambda: model.generate_voice_design(
+            text=args.second_text,
+            instruct=args.instruct,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+        fresh_stream = lambda: model.generate_voice_design_streaming(
+            text=args.second_text,
+            instruct=args.instruct,
+            chunk_size=args.chunk_size,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+
+    print("Warmup run (includes graph capture)...")
+    _ = first_call(max_new_tokens=20)
+
+    print("Preparing continuation state from the first sentence...")
+    first_result = first_call()
+    state = first_result[2]["continuation_state"]
+
+    if args.mode == "voice_clone":
+        cont_nonstream = lambda: model.generate_voice_clone(
+            text=args.second_text,
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            xvec_only=args.xvec_only,
+            continuation_state=state,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+        cont_stream = lambda: model.generate_voice_clone_streaming(
+            text=args.second_text,
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            xvec_only=args.xvec_only,
+            chunk_size=args.chunk_size,
+            continuation_state=state,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+    elif args.mode == "custom_voice":
+        cont_nonstream = lambda: model.generate_custom_voice(
+            text=args.second_text,
+            speaker=speaker,
+            instruct=args.instruct,
+            continuation_state=state,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+        cont_stream = lambda: model.generate_custom_voice_streaming(
+            text=args.second_text,
+            speaker=speaker,
+            instruct=args.instruct,
+            chunk_size=args.chunk_size,
+            continuation_state=state,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+    else:
+        cont_nonstream = lambda: model.generate_voice_design(
+            text=args.second_text,
+            instruct=args.instruct,
+            continuation_state=state,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+        cont_stream = lambda: model.generate_voice_design_streaming(
+            text=args.second_text,
+            instruct=args.instruct,
+            chunk_size=args.chunk_size,
+            continuation_state=state,
+            return_continuation_state="delta",
+            max_new_tokens=args.max_new_tokens,
+            **common_kwargs,
+        )
+
+    print("\n=== Second sentence only ===")
+    ttfa_fresh = _measure_stream_ttfa(fresh_stream, args.runs)
+    ttfa_cont = _measure_stream_ttfa(cont_stream, args.runs)
+    ns_fresh = _measure_nonstream(fresh_nonstream, args.runs)
+    ns_cont = _measure_nonstream(cont_nonstream, args.runs)
+
+    print(
+        f"fresh        | TTFA={ttfa_fresh[0]:7.1f}ms ± {ttfa_fresh[1]:5.1f} | "
+        f"latency={ns_fresh[0]:7.1f}ms ± {ns_fresh[1]:5.1f} | "
+        f"RTF={ns_fresh[2]:.3f} ± {ns_fresh[3]:.3f}"
+    )
+    print(
+        f"continuation | TTFA={ttfa_cont[0]:7.1f}ms ± {ttfa_cont[1]:5.1f} | "
+        f"latency={ns_cont[0]:7.1f}ms ± {ns_cont[1]:5.1f} | "
+        f"RTF={ns_cont[2]:.3f} ± {ns_cont[3]:.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/index.html
+++ b/demo/index.html
@@ -493,6 +493,102 @@ body {
 .wave i:nth-child(4) { height: 7px;  animation-delay: 0.3s; }
 .wave i:nth-child(5) { height: 3px;  animation-delay: 0.4s; }
 
+/* ── Continuation compare ── */
+.continuation {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.continuation-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+  flex-wrap: wrap;
+}
+.continuation-head h2 {
+  font-size: 13px; font-weight: 600; letter-spacing: -0.2px;
+}
+.continuation-sub {
+  font-size: 11px; color: var(--dim);
+}
+.continuation textarea {
+  width: 100%; min-height: 72px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 9px 10px;
+  resize: vertical;
+  outline: none;
+}
+.continuation textarea:focus { border-color: var(--accent-ring); }
+.continuation textarea::placeholder { color: var(--dimmer); }
+.continuation textarea:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+.continuation-actions {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  flex-wrap: wrap;
+}
+.continuation-status {
+  font-size: 11px; color: var(--dim);
+}
+.compare-btn {
+  padding: 7px 14px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+.compare-btn:hover:not(:disabled) { background: var(--accent2); }
+.compare-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.compare-grid {
+  display: none;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+.compare-grid.show { display: grid; }
+.compare-card {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 9px 10px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.compare-title {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  font-size: 12px; font-weight: 600;
+}
+.compare-badge {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+.compare-badge.fresh {
+  color: var(--amber);
+  background: rgba(234,179,8,0.12);
+  border: 1px solid rgba(234,179,8,0.25);
+}
+.compare-badge.cont {
+  color: var(--green);
+  background: rgba(34,197,94,0.12);
+  border: 1px solid rgba(34,197,94,0.25);
+}
+.compare-card audio {
+  width: 100%;
+  height: 32px;
+  border-radius: 4px;
+}
+:root:not([data-theme="light"]) .compare-card audio { filter: invert(0.88) hue-rotate(180deg); }
+
 /* ── Settings overlay ── */
 .sov {
   position: fixed; inset: 0;
@@ -615,6 +711,7 @@ body {
   }
   .s-grid3 .s-row { flex-direction: column; align-items: stretch; margin-bottom: 0; }
   .s-grid3 .s-row label { min-width: unset; margin-bottom: 4px; }
+  .compare-grid { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-height: 520px) {
   .app { padding: 6px 12px; gap: 6px; }
@@ -753,6 +850,44 @@ body {
       </div>
     </div>
 
+    <div class="continuation" id="continuationWrap">
+      <div class="continuation-head">
+        <h2>Continue Previous Sentence</h2>
+        <span class="continuation-sub">Render the next sentence twice: fresh and with continuation state.</span>
+      </div>
+      <textarea id="continuationText" placeholder="Enter the follow-up sentence you want to compare..." oninput="updateContinuationControls()"></textarea>
+      <div class="continuation-actions">
+        <span class="continuation-status" id="continuationStatus">Generate a first sentence to unlock this comparison.</span>
+        <button class="compare-btn" id="continuationBtn" onclick="compareContinuation()" disabled>Compare fresh vs continued</button>
+      </div>
+      <div class="compare-grid" id="continuationResults">
+        <div class="compare-card">
+          <div class="compare-title">
+            <span>Fresh second sentence</span>
+            <span class="compare-badge fresh">No continuation</span>
+          </div>
+          <audio id="cmpFreshPlayer" controls></audio>
+          <div class="metrics">
+            <div class="met"><span class="met-k">Total</span><span class="met-v" id="cmpFreshMs">&mdash;</span></div>
+            <div class="met"><span class="met-k">RTF</span><span class="met-v" id="cmpFreshRTF">&mdash;</span></div>
+            <div class="met"><span class="met-k">Dur</span><span class="met-v" id="cmpFreshDur">&mdash;</span></div>
+          </div>
+        </div>
+        <div class="compare-card">
+          <div class="compare-title">
+            <span>Continued second sentence</span>
+            <span class="compare-badge cont">Continuation</span>
+          </div>
+          <audio id="cmpContPlayer" controls></audio>
+          <div class="metrics">
+            <div class="met"><span class="met-k">Total</span><span class="met-v" id="cmpContMs">&mdash;</span></div>
+            <div class="met"><span class="met-k">RTF</span><span class="met-v" id="cmpContRTF">&mdash;</span></div>
+            <div class="met"><span class="met-k">Dur</span><span class="met-v" id="cmpContDur">&mdash;</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 
 </div><!-- /.app -->
@@ -865,6 +1000,7 @@ function autoGrow(el) {
 
 function setPlayBtns(disabled) {
   document.querySelectorAll('.play-btn').forEach(b => b.disabled = disabled);
+  updateContinuationControls();
 }
 
 // ── State ─────────────────────────────────────────────────────────────────────
@@ -878,6 +1014,7 @@ let presetRefs = [];
 let loadedModel  = null;
 let loadingModel = null;
 let dlBlob   = null;
+let lastContinuationSessionId = null;
 
 const defaultSpeakers = [
   { id: 'Vivian',   desc: 'Chinese — Bright young female' },
@@ -907,7 +1044,9 @@ const REC_SR = 24000;
 window.addEventListener('load', async () => {
   initTheme();
   autoGrow($('voiceInstr'));
+  autoGrow($('continuationText'));
   await fetchStatus();
+  setContinuationSession(null);
   if (!loadedModel && availableModels.length > 0) {
     // Prefer CustomVoice as default (richer demo), fall back to first available
     const preferred = availableModels.find(m => m.includes('CustomVoice'))
@@ -1072,6 +1211,7 @@ async function loadModel() {
   btn.disabled = true; btn.textContent = 'Loading...';
   loadingModel = $('modelSel').value;
   loadedModel  = null;
+  setContinuationSession(null);
   setPlayBtns(true);
   setPill('loading', 'loading...');
   try {
@@ -1693,6 +1833,7 @@ async function runStream(fd) {
         setDone();
         const blob = buildFinalWav();
         if (blob) setPlayer(blob);
+        setContinuationSession(d.continuation_session_id);
 
       } else if (d.type === 'error') {
         $('queueBar').className = 'queue-bar';
@@ -1713,6 +1854,7 @@ async function runNonStream(fd) {
   const bytes = Uint8Array.from(atob(d.audio_b64), c => c.charCodeAt(0));
   const blob  = new Blob([bytes], { type: 'audio/wav' });
   setPlayer(blob);
+  setContinuationSession(d.continuation_session_id);
   $('player').play().catch(() => {}); // gracefully handle autoplay block
 }
 
@@ -1749,6 +1891,107 @@ function setPlayer(blob) {
   dlBlob = blob;
   $('player').src = URL.createObjectURL(blob);
   $('player').parentElement.style.display = '';
+}
+
+function clearAudioPlayer(id) {
+  const el = $(id);
+  if (!el) return;
+  el.pause();
+  if (el.src && el.src.startsWith('blob:')) URL.revokeObjectURL(el.src);
+  el.removeAttribute('src');
+  el.load();
+}
+
+function resetComparisonMetrics() {
+  ['cmpFreshMs', 'cmpFreshRTF', 'cmpFreshDur', 'cmpContMs', 'cmpContRTF', 'cmpContDur']
+    .forEach(id => $(id).innerHTML = '&mdash;');
+}
+
+function clearContinuationResults() {
+  clearAudioPlayer('cmpFreshPlayer');
+  clearAudioPlayer('cmpContPlayer');
+  resetComparisonMetrics();
+  $('continuationResults').classList.remove('show');
+}
+
+function setContinuationSession(sessionId) {
+  const nextSessionId = sessionId || null;
+  const changed = nextSessionId !== lastContinuationSessionId;
+  lastContinuationSessionId = nextSessionId;
+  if (changed) clearContinuationResults();
+  updateContinuationControls();
+}
+
+function updateContinuationControls() {
+  const hasSession = !!lastContinuationSessionId;
+  const hasText = !!$('continuationText').value.trim();
+  const btn = $('continuationBtn');
+  const status = $('continuationStatus');
+
+  btn.disabled = busy || !hasSession || !hasText;
+  if (!hasSession) {
+    status.textContent = 'Generate a first sentence to unlock this comparison.';
+  } else if (busy) {
+    status.textContent = 'Generation in progress…';
+  } else {
+    status.textContent = 'Uses the last completed clip as sentence 1.';
+  }
+}
+
+function setComparisonResult(kind, payload) {
+  const playerId = kind === 'fresh' ? 'cmpFreshPlayer' : 'cmpContPlayer';
+  const msId = kind === 'fresh' ? 'cmpFreshMs' : 'cmpContMs';
+  const rtfId = kind === 'fresh' ? 'cmpFreshRTF' : 'cmpContRTF';
+  const durId = kind === 'fresh' ? 'cmpFreshDur' : 'cmpContDur';
+
+  clearAudioPlayer(playerId);
+  const bytes = Uint8Array.from(atob(payload.audio_b64), c => c.charCodeAt(0));
+  const blob = new Blob([bytes], { type: 'audio/wav' });
+  $(playerId).src = URL.createObjectURL(blob);
+  $(msId).textContent = payload.metrics.total_ms + 'ms';
+  $(rtfId).textContent = payload.metrics.rtf.toFixed(2) + 'x';
+  $(durId).textContent = payload.metrics.audio_duration_s.toFixed(1) + 's';
+  $('continuationResults').classList.add('show');
+}
+
+async function compareContinuation() {
+  if (busy || !lastContinuationSessionId) return;
+  const text = $('continuationText').value.trim();
+  if (!text) {
+    showMsg('err', 'Enter the follow-up sentence first.');
+    return;
+  }
+
+  hideMsg();
+  busy = true;
+  setPlayBtns(true);
+  clearContinuationResults();
+  $('continuationStatus').textContent = 'Comparing fresh vs continued…';
+
+  const fd = new FormData();
+  fd.append('session_id', lastContinuationSessionId);
+  fd.append('text', text);
+  fd.append('temperature', $('tempSl').value);
+  fd.append('top_k', $('topkSl').value);
+  fd.append('repetition_penalty', $('repSl').value);
+
+  try {
+    const res = await fetch('/generate/compare_continuation', { method: 'POST', body: fd });
+    if (!res.ok) {
+      const e = await res.json();
+      throw new Error(e.detail || 'Comparison failed');
+    }
+    const d = await res.json();
+    setComparisonResult('fresh', d.fresh);
+    setComparisonResult('cont', d.continued);
+    setContinuationSession(d.continuation_session_id);
+  } catch (e) {
+    showMsg('err', 'Continuation comparison failed: ' + e.message);
+  } finally {
+    busy = false;
+    setPlayBtns(false);
+    updateContinuationControls();
+  }
 }
 
 // ── Messages ──────────────────────────────────────────────────────────────────

--- a/demo/index.html
+++ b/demo/index.html
@@ -853,7 +853,7 @@ body {
     <div class="continuation" id="continuationWrap">
       <div class="continuation-head">
         <h2>Continue Previous Sentence</h2>
-        <span class="continuation-sub">Render the next sentence twice: fresh and with continuation state.</span>
+        <span class="continuation-sub">Each player starts with the tail of sentence 1, then plays sentence 2 fresh or continued. Re-run compare to test different sentence 2 options against the same sentence 1.</span>
       </div>
       <textarea id="continuationText" placeholder="Enter the follow-up sentence you want to compare..." oninput="updateContinuationControls()"></textarea>
       <div class="continuation-actions">
@@ -870,7 +870,7 @@ body {
           <div class="metrics">
             <div class="met"><span class="met-k">Total</span><span class="met-v" id="cmpFreshMs">&mdash;</span></div>
             <div class="met"><span class="met-k">RTF</span><span class="met-v" id="cmpFreshRTF">&mdash;</span></div>
-            <div class="met"><span class="met-k">Dur</span><span class="met-v" id="cmpFreshDur">&mdash;</span></div>
+            <div class="met"><span class="met-k">Gen dur</span><span class="met-v" id="cmpFreshDur">&mdash;</span></div>
           </div>
         </div>
         <div class="compare-card">
@@ -882,7 +882,7 @@ body {
           <div class="metrics">
             <div class="met"><span class="met-k">Total</span><span class="met-v" id="cmpContMs">&mdash;</span></div>
             <div class="met"><span class="met-k">RTF</span><span class="met-v" id="cmpContRTF">&mdash;</span></div>
-            <div class="met"><span class="met-k">Dur</span><span class="met-v" id="cmpContDur">&mdash;</span></div>
+            <div class="met"><span class="met-k">Gen dur</span><span class="met-v" id="cmpContDur">&mdash;</span></div>
           </div>
         </div>
       </div>
@@ -1934,7 +1934,7 @@ function updateContinuationControls() {
   } else if (busy) {
     status.textContent = 'Generation in progress…';
   } else {
-    status.textContent = 'Uses the last completed clip as sentence 1.';
+    status.textContent = 'Uses the last generated first sentence as sentence 1 until you generate a new one.';
   }
 }
 

--- a/demo/server.py
+++ b/demo/server.py
@@ -35,7 +35,7 @@ from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 try:
-    from faster_qwen3_tts import FasterQwen3TTS
+    from faster_qwen3_tts import FasterQwen3TTS, apply_continuation_state_delta
 except ImportError:
     print("Error: faster_qwen3_tts not found.")
     print("Install with:  pip install -e .  (from the repo root)")
@@ -166,6 +166,9 @@ _ref_cache_lock = threading.Lock()
 _parakeet = None
 _generation_lock = asyncio.Lock()
 _generation_waiters: int = 0  # requests waiting for or holding the generation lock
+_continuation_sessions: OrderedDict[str, dict] = OrderedDict()
+_continuation_sessions_max: int = int(os.environ.get("CONTINUATION_SESSION_CACHE_SIZE", "4"))
+_continuation_sessions_lock = threading.Lock()
 
 # Guard against inputs that would overflow the static KV cache (max_seq_len=2048).
 # At ~3-4 chars/token for English the overhead of system/ref tokens leaves room
@@ -214,6 +217,120 @@ def _get_cached_ref_path(content: bytes) -> str:
 
 def _default_non_streaming_mode_for_mode(mode: str) -> bool:
     return mode != "voice_clone"
+
+
+def _clear_continuation_sessions() -> None:
+    with _continuation_sessions_lock:
+        _continuation_sessions.clear()
+
+
+def _make_continuation_session_id() -> str:
+    token = f"{time.time_ns()}-{os.getpid()}-{threading.get_ident()}".encode()
+    return hashlib.sha1(token).hexdigest()[:16]
+
+
+def _build_continuation_template(
+    *,
+    mode: str,
+    language: str,
+    non_streaming_mode: bool,
+    ref_audio_path: str | None = None,
+    ref_text: str = "",
+    xvec_only: bool = True,
+    speaker: str = "",
+    instruct: str = "",
+) -> dict:
+    return {
+        "mode": mode,
+        "language": language,
+        "non_streaming_mode": bool(non_streaming_mode),
+        "ref_audio_path": ref_audio_path,
+        "ref_text": ref_text,
+        "xvec_only": bool(xvec_only),
+        "speaker": speaker,
+        "instruct": instruct,
+    }
+
+
+def _store_continuation_session(*, model_name: str, template: dict, state: dict) -> str:
+    session_id = _make_continuation_session_id()
+    with _continuation_sessions_lock:
+        _continuation_sessions[session_id] = {
+            "id": session_id,
+            "model_name": model_name,
+            "template": template,
+            "state": state,
+            "created_at": time.time(),
+        }
+        _continuation_sessions.move_to_end(session_id)
+        while len(_continuation_sessions) > _continuation_sessions_max:
+            _continuation_sessions.popitem(last=False)
+    return session_id
+
+
+def _get_continuation_session(session_id: str) -> dict | None:
+    with _continuation_sessions_lock:
+        session = _continuation_sessions.get(session_id)
+        if session is None:
+            return None
+        _continuation_sessions.move_to_end(session_id)
+        return session
+
+
+def _update_continuation_session(session_id: str, state: dict) -> None:
+    with _continuation_sessions_lock:
+        session = _continuation_sessions.get(session_id)
+        if session is None:
+            return
+        session["state"] = state
+        _continuation_sessions.move_to_end(session_id)
+
+
+def _run_demo_generation(
+    model: FasterQwen3TTS,
+    *,
+    template: dict,
+    text: str,
+    temperature: float,
+    top_k: int,
+    repetition_penalty: float,
+    continuation_state: dict | None = None,
+    return_continuation_state: bool | str = False,
+    max_new_tokens: int = 360,
+):
+    common = {
+        "text": text,
+        "language": template["language"],
+        "non_streaming_mode": template["non_streaming_mode"],
+        "temperature": temperature,
+        "top_k": top_k,
+        "repetition_penalty": repetition_penalty,
+        "max_new_tokens": max_new_tokens,
+    }
+    if continuation_state is not None:
+        common["continuation_state"] = continuation_state
+    if return_continuation_state:
+        common["return_continuation_state"] = return_continuation_state
+        common["continuation_state_device"] = "cpu"
+
+    mode = template["mode"]
+    if mode == "voice_clone":
+        return model.generate_voice_clone(
+            ref_audio=template["ref_audio_path"],
+            ref_text=template["ref_text"],
+            xvec_only=template["xvec_only"],
+            **common,
+        )
+    if mode == "custom":
+        return model.generate_custom_voice(
+            speaker=template["speaker"],
+            instruct=template["instruct"],
+            **common,
+        )
+    return model.generate_voice_design(
+        instruct=template["instruct"],
+        **common,
+    )
 
 
 # ─── Routes ───────────────────────────────────────────────────────────────────
@@ -300,6 +417,7 @@ async def load_model(model_id: str = Form(...)):
 
     # Already in cache — instant switch, no GPU work needed
     if model_id in _model_cache:
+        _clear_continuation_sessions()
         _active_model_name = model_id
         _model_cache.move_to_end(model_id)
         return {"status": "already_loaded", "model": model_id}
@@ -309,6 +427,7 @@ async def load_model(model_id: str = Form(...)):
     def _do_load():
         global _active_model_name, _loading
         try:
+            _clear_continuation_sessions()
             if len(_model_cache) >= _model_cache_max:
                 evicted, _ = _model_cache.popitem(last=False)
                 print(f"Model cache full — evicted: {evicted}")
@@ -380,6 +499,17 @@ async def generate_stream(
     if non_streaming_mode is None:
         non_streaming_mode = _default_non_streaming_mode_for_mode(mode)
 
+    template = _build_continuation_template(
+        mode=mode,
+        language=language,
+        non_streaming_mode=non_streaming_mode,
+        ref_audio_path=tmp_path,
+        ref_text=ref_text,
+        xvec_only=xvec_only,
+        speaker=speaker,
+        instruct=instruct,
+    )
+
     loop = asyncio.get_event_loop()
     queue: asyncio.Queue[str | None] = asyncio.Queue()
 
@@ -395,6 +525,7 @@ async def generate_stream(
             t0 = time.perf_counter()
             total_audio_s = 0.0
             voice_clone_ms = 0.0
+            running_state = None
 
             if mode == "voice_clone":
                 gen = model.generate_voice_clone_streaming(
@@ -408,6 +539,8 @@ async def generate_stream(
                     temperature=temperature,
                     top_k=top_k,
                     repetition_penalty=repetition_penalty,
+                    return_continuation_state="delta",
+                    continuation_state_device="cpu",
                     max_new_tokens=360,  # cap at 30s (12 Hz codec)
                 )
             elif mode == "custom":
@@ -423,6 +556,8 @@ async def generate_stream(
                     temperature=temperature,
                     top_k=top_k,
                     repetition_penalty=repetition_penalty,
+                    return_continuation_state="delta",
+                    continuation_state_device="cpu",
                     max_new_tokens=360,
                 )
             else:
@@ -435,6 +570,8 @@ async def generate_stream(
                     temperature=temperature,
                     top_k=top_k,
                     repetition_penalty=repetition_penalty,
+                    return_continuation_state="delta",
+                    continuation_state_device="cpu",
                     max_new_tokens=360,
                 )
 
@@ -447,6 +584,9 @@ async def generate_stream(
             first_audio = next(gen, None)
             if first_audio is not None:
                 audio_chunk, sr, timing = first_audio
+                delta = timing.get("continuation_state_delta")
+                if delta is not None:
+                    running_state = apply_continuation_state_delta(running_state, delta)
                 wall_first_ms = (time.perf_counter() - t0) * 1000
                 model_ms = timing.get("prefill_ms", 0) + timing.get("decode_ms", 0)
                 voice_clone_ms = max(0.0, wall_first_ms - model_ms)
@@ -473,6 +613,9 @@ async def generate_stream(
                 loop.call_soon_threadsafe(queue.put_nowait, json.dumps(payload))
 
             for audio_chunk, sr, timing in gen:
+                delta = timing.get("continuation_state_delta")
+                if delta is not None:
+                    running_state = apply_continuation_state_delta(running_state, delta)
                 # prefill_ms is non-zero only on the first chunk
                 total_gen_ms += timing.get('prefill_ms', 0) + timing.get('decode_ms', 0)
                 if ttfa_ms is None:
@@ -497,6 +640,13 @@ async def generate_stream(
                 loop.call_soon_threadsafe(queue.put_nowait, json.dumps(payload))
 
             rtf = total_audio_s / (total_gen_ms / 1000) if total_gen_ms > 0 else 0.0
+            session_id = None
+            if running_state is not None:
+                session_id = _store_continuation_session(
+                    model_name=_active_model_name,
+                    template=template,
+                    state=running_state,
+                )
             done_payload = {
                 "type": "done",
                 "ttfa_ms": round(ttfa_ms) if ttfa_ms else 0,
@@ -504,6 +654,7 @@ async def generate_stream(
                 "rtf": round(rtf, 3),
                 "total_audio_s": round(total_audio_s, 3),
                 "total_ms": round((time.perf_counter() - t0) * 1000),
+                "continuation_session_id": session_id,
             }
             loop.call_soon_threadsafe(queue.put_nowait, json.dumps(done_payload))
 
@@ -600,54 +751,48 @@ async def generate_non_streaming(
     if non_streaming_mode is None:
         non_streaming_mode = _default_non_streaming_mode_for_mode(mode)
 
+    template = _build_continuation_template(
+        mode=mode,
+        language=language,
+        non_streaming_mode=non_streaming_mode,
+        ref_audio_path=tmp_path,
+        ref_text=ref_text,
+        xvec_only=xvec_only,
+        speaker=speaker,
+        instruct=instruct,
+    )
+
     def run():
         # Resolve the model after the generation lock is held.
         model = _model_cache.get(_active_model_name)
         if model is None:
             raise RuntimeError("No model loaded. Please load a model first.")
         t0 = time.perf_counter()
-        if mode == "voice_clone":
-            audio_list, sr = model.generate_voice_clone(
-                text=text,
-                language=language,
-                ref_audio=tmp_path,
-                ref_text=ref_text,
-                xvec_only=xvec_only,
-                non_streaming_mode=non_streaming_mode,
-                temperature=temperature,
-                top_k=top_k,
-                repetition_penalty=repetition_penalty,
-                max_new_tokens=360,  # cap at 30s (12 Hz codec)
-            )
-        elif mode == "custom":
-            if not speaker:
-                raise ValueError("Speaker ID is required for custom voice")
-            audio_list, sr = model.generate_custom_voice(
-                text=text,
-                speaker=speaker,
-                language=language,
-                instruct=instruct,
-                non_streaming_mode=non_streaming_mode,
-                temperature=temperature,
-                top_k=top_k,
-                repetition_penalty=repetition_penalty,
-                max_new_tokens=360,
-            )
-        else:
-            audio_list, sr = model.generate_voice_design(
-                text=text,
-                instruct=instruct,
-                language=language,
-                non_streaming_mode=non_streaming_mode,
-                temperature=temperature,
-                top_k=top_k,
-                repetition_penalty=repetition_penalty,
-                max_new_tokens=360,
-            )
+        if mode == "custom" and not speaker:
+            raise ValueError("Speaker ID is required for custom voice")
+        result = _run_demo_generation(
+            model,
+            template=template,
+            text=text,
+            temperature=temperature,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+            return_continuation_state="full",
+            max_new_tokens=360,
+        )
+        audio_list, sr, info = result
         elapsed = time.perf_counter() - t0
         audio = _concat_audio(audio_list)
         dur = len(audio) / sr
-        return audio, sr, elapsed, dur
+        session_id = None
+        state = info.get("continuation_state") if info else None
+        if state is not None:
+            session_id = _store_continuation_session(
+                model_name=_active_model_name,
+                template=template,
+                state=state,
+            )
+        return audio, sr, elapsed, dur, session_id
 
     global _generation_waiters
     _generation_waiters += 1
@@ -656,11 +801,12 @@ async def generate_non_streaming(
         await _generation_lock.acquire()
         lock_acquired = True
         _generation_waiters -= 1
-        audio, sr, elapsed, dur = await asyncio.to_thread(run)
+        audio, sr, elapsed, dur, session_id = await asyncio.to_thread(run)
         rtf = dur / elapsed if elapsed > 0 else 0.0
         return JSONResponse({
             "audio_b64": _to_wav_b64(audio, sr),
             "sample_rate": sr,
+            "continuation_session_id": session_id,
             "metrics": {
                 "total_ms": round(elapsed * 1000),
                 "audio_duration_s": round(dur, 3),
@@ -674,6 +820,110 @@ async def generate_non_streaming(
             _generation_waiters -= 1
         if tmp_path and os.path.exists(tmp_path) and not tmp_is_cached:
             os.unlink(tmp_path)
+
+
+@app.post("/generate/compare_continuation")
+async def generate_continuation_compare(
+    session_id: str = Form(...),
+    text: str = Form(...),
+    temperature: float = Form(0.9),
+    top_k: int = Form(50),
+    repetition_penalty: float = Form(1.05),
+):
+    if not _active_model_name or _active_model_name not in _model_cache:
+        raise HTTPException(status_code=400, detail="Model not loaded. Click 'Load' first.")
+    if len(text) > MAX_TEXT_CHARS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Text too long ({len(text)} chars). Maximum is {MAX_TEXT_CHARS} characters.",
+        )
+
+    def run():
+        model = _model_cache.get(_active_model_name)
+        if model is None:
+            raise RuntimeError("No model loaded. Please load a model first.")
+
+        session = _get_continuation_session(session_id)
+        if session is None:
+            raise RuntimeError("Saved continuation state not found. Generate the first sentence again.")
+        if session["model_name"] != _active_model_name:
+            raise RuntimeError("Saved continuation state belongs to a different model. Generate the first sentence again.")
+
+        template = session["template"]
+        mode = template["mode"]
+        if mode == "custom" and not template["speaker"]:
+            raise RuntimeError("Saved continuation state is missing the custom speaker.")
+
+        t0 = time.perf_counter()
+        fresh_result = _run_demo_generation(
+            model,
+            template=template,
+            text=text,
+            temperature=temperature,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+            max_new_tokens=360,
+        )
+        fresh_elapsed = time.perf_counter() - t0
+        fresh_audio_list, fresh_sr = fresh_result
+        fresh_audio = _concat_audio(fresh_audio_list)
+        fresh_dur = len(fresh_audio) / fresh_sr
+
+        t1 = time.perf_counter()
+        continued_result = _run_demo_generation(
+            model,
+            template=template,
+            text=text,
+            temperature=temperature,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+            continuation_state=session["state"],
+            return_continuation_state="full",
+            max_new_tokens=360,
+        )
+        cont_elapsed = time.perf_counter() - t1
+        cont_audio_list, cont_sr, cont_info = continued_result
+        cont_audio = _concat_audio(cont_audio_list)
+        cont_dur = len(cont_audio) / cont_sr
+        cont_state = cont_info.get("continuation_state") if cont_info else None
+        if cont_state is not None:
+            _update_continuation_session(session_id, cont_state)
+
+        return {
+            "continuation_session_id": session_id,
+            "fresh": {
+                "audio_b64": _to_wav_b64(fresh_audio, fresh_sr),
+                "sample_rate": fresh_sr,
+                "metrics": {
+                    "total_ms": round(fresh_elapsed * 1000),
+                    "audio_duration_s": round(fresh_dur, 3),
+                    "rtf": round(fresh_dur / fresh_elapsed, 3) if fresh_elapsed > 0 else 0.0,
+                },
+            },
+            "continued": {
+                "audio_b64": _to_wav_b64(cont_audio, cont_sr),
+                "sample_rate": cont_sr,
+                "metrics": {
+                    "total_ms": round(cont_elapsed * 1000),
+                    "audio_duration_s": round(cont_dur, 3),
+                    "rtf": round(cont_dur / cont_elapsed, 3) if cont_elapsed > 0 else 0.0,
+                },
+            },
+        }
+
+    global _generation_waiters
+    _generation_waiters += 1
+    lock_acquired = False
+    try:
+        await _generation_lock.acquire()
+        lock_acquired = True
+        _generation_waiters -= 1
+        return JSONResponse(await asyncio.to_thread(run))
+    finally:
+        if lock_acquired:
+            _generation_lock.release()
+        else:
+            _generation_waiters -= 1
 
 
 # ─── Entry point ──────────────────────────────────────────────────────────────

--- a/demo/server.py
+++ b/demo/server.py
@@ -176,6 +176,9 @@ _continuation_sessions_lock = threading.Lock()
 MAX_TEXT_CHARS = 1000
 # ~10 MB covers 1 minute of 44.1 kHz stereo 16-bit WAV.
 MAX_AUDIO_BYTES = 10 * 1024 * 1024
+CONTINUATION_COMPARE_CONTEXT_SECONDS = float(
+    os.environ.get("CONTINUATION_COMPARE_CONTEXT_SECONDS", "2.0")
+)
 _AUDIO_TOO_LARGE_MSG = (
     "Audio file too large ({size_mb:.1f} MB). "
     "Voice cloning works best with short clips under 1 minute — please upload a shorter recording."
@@ -200,6 +203,45 @@ def _concat_audio(audio_list) -> np.ndarray:
         return audio_list.astype(np.float32).squeeze()
     parts = [np.array(a, dtype=np.float32).squeeze() for a in audio_list if len(a) > 0]
     return np.concatenate(parts) if parts else np.zeros(0, dtype=np.float32)
+
+
+def _trim_audio_tail(audio: np.ndarray, sr: int, seconds: float = CONTINUATION_COMPARE_CONTEXT_SECONDS) -> np.ndarray:
+    audio = np.array(audio, dtype=np.float32).squeeze()
+    if sr <= 0 or seconds <= 0 or audio.size == 0:
+        return np.zeros(0, dtype=np.float32)
+    keep = max(1, int(round(sr * seconds)))
+    if audio.size <= keep:
+        return audio
+    return audio[-keep:]
+
+
+def _append_audio_tail(
+    current_tail: np.ndarray | None,
+    chunk: np.ndarray,
+    sr: int,
+    seconds: float = CONTINUATION_COMPARE_CONTEXT_SECONDS,
+) -> np.ndarray:
+    chunk = np.array(chunk, dtype=np.float32).squeeze()
+    if current_tail is None or current_tail.size == 0:
+        return _trim_audio_tail(chunk, sr, seconds)
+    if chunk.size == 0:
+        return _trim_audio_tail(current_tail, sr, seconds)
+    combined = np.concatenate([current_tail, chunk])
+    return _trim_audio_tail(combined, sr, seconds)
+
+
+def _prepend_context_audio(context_audio: np.ndarray, context_sr: int, audio: np.ndarray, sr: int) -> np.ndarray:
+    audio = np.array(audio, dtype=np.float32).squeeze()
+    context_audio = np.array(context_audio, dtype=np.float32).squeeze()
+    if context_audio.size == 0:
+        return audio
+    if context_sr != sr:
+        context_audio = torchaudio.functional.resample(
+            torch.from_numpy(context_audio).unsqueeze(0),
+            context_sr,
+            sr,
+        ).squeeze(0).cpu().numpy()
+    return np.concatenate([context_audio.astype(np.float32), audio])
 
 def _get_cached_ref_path(content: bytes) -> str:
     digest = hashlib.sha1(content).hexdigest()
@@ -252,7 +294,14 @@ def _build_continuation_template(
     }
 
 
-def _store_continuation_session(*, model_name: str, template: dict, state: dict) -> str:
+def _store_continuation_session(
+    *,
+    model_name: str,
+    template: dict,
+    state: dict,
+    audio_tail: np.ndarray,
+    sample_rate: int,
+) -> str:
     session_id = _make_continuation_session_id()
     with _continuation_sessions_lock:
         _continuation_sessions[session_id] = {
@@ -260,6 +309,8 @@ def _store_continuation_session(*, model_name: str, template: dict, state: dict)
             "model_name": model_name,
             "template": template,
             "state": state,
+            "audio_tail": np.array(audio_tail, dtype=np.float32).copy(),
+            "sample_rate": int(sample_rate),
             "created_at": time.time(),
         }
         _continuation_sessions.move_to_end(session_id)
@@ -275,15 +326,6 @@ def _get_continuation_session(session_id: str) -> dict | None:
             return None
         _continuation_sessions.move_to_end(session_id)
         return session
-
-
-def _update_continuation_session(session_id: str, state: dict) -> None:
-    with _continuation_sessions_lock:
-        session = _continuation_sessions.get(session_id)
-        if session is None:
-            return
-        session["state"] = state
-        _continuation_sessions.move_to_end(session_id)
 
 
 def _run_demo_generation(
@@ -526,6 +568,8 @@ async def generate_stream(
             total_audio_s = 0.0
             voice_clone_ms = 0.0
             running_state = None
+            running_tail = np.zeros(0, dtype=np.float32)
+            running_sr = None
 
             if mode == "voice_clone":
                 gen = model.generate_voice_clone_streaming(
@@ -595,6 +639,8 @@ async def generate_stream(
                     ttfa_ms = total_gen_ms
 
                 audio_chunk = _concat_audio(audio_chunk)
+                running_sr = sr
+                running_tail = _append_audio_tail(running_tail, audio_chunk, sr)
                 dur = len(audio_chunk) / sr
                 total_audio_s += dur
                 rtf = total_audio_s / (total_gen_ms / 1000) if total_gen_ms > 0 else 0.0
@@ -622,6 +668,8 @@ async def generate_stream(
                     ttfa_ms = total_gen_ms  # already in ms
 
                 audio_chunk = _concat_audio(audio_chunk)
+                running_sr = sr
+                running_tail = _append_audio_tail(running_tail, audio_chunk, sr)
                 dur = len(audio_chunk) / sr
                 total_audio_s += dur
                 rtf = total_audio_s / (total_gen_ms / 1000) if total_gen_ms > 0 else 0.0
@@ -646,6 +694,8 @@ async def generate_stream(
                     model_name=_active_model_name,
                     template=template,
                     state=running_state,
+                    audio_tail=running_tail,
+                    sample_rate=running_sr or 24000,
                 )
             done_payload = {
                 "type": "done",
@@ -791,6 +841,8 @@ async def generate_non_streaming(
                 model_name=_active_model_name,
                 template=template,
                 state=state,
+                audio_tail=_trim_audio_tail(audio, sr),
+                sample_rate=sr,
             )
         return audio, sr, elapsed, dur, session_id
 
@@ -853,6 +905,8 @@ async def generate_continuation_compare(
         mode = template["mode"]
         if mode == "custom" and not template["speaker"]:
             raise RuntimeError("Saved continuation state is missing the custom speaker.")
+        context_audio = np.array(session.get("audio_tail", np.zeros(0, dtype=np.float32)), dtype=np.float32)
+        context_sr = int(session.get("sample_rate", 24000))
 
         t0 = time.perf_counter()
         fresh_result = _run_demo_generation(
@@ -867,6 +921,7 @@ async def generate_continuation_compare(
         fresh_elapsed = time.perf_counter() - t0
         fresh_audio_list, fresh_sr = fresh_result
         fresh_audio = _concat_audio(fresh_audio_list)
+        fresh_compare_audio = _prepend_context_audio(context_audio, context_sr, fresh_audio, fresh_sr)
         fresh_dur = len(fresh_audio) / fresh_sr
 
         t1 = time.perf_counter()
@@ -878,21 +933,19 @@ async def generate_continuation_compare(
             top_k=top_k,
             repetition_penalty=repetition_penalty,
             continuation_state=session["state"],
-            return_continuation_state="full",
             max_new_tokens=360,
         )
         cont_elapsed = time.perf_counter() - t1
-        cont_audio_list, cont_sr, cont_info = continued_result
+        cont_audio_list, cont_sr = continued_result
         cont_audio = _concat_audio(cont_audio_list)
+        cont_compare_audio = _prepend_context_audio(context_audio, context_sr, cont_audio, cont_sr)
         cont_dur = len(cont_audio) / cont_sr
-        cont_state = cont_info.get("continuation_state") if cont_info else None
-        if cont_state is not None:
-            _update_continuation_session(session_id, cont_state)
 
         return {
             "continuation_session_id": session_id,
+            "context_seconds": CONTINUATION_COMPARE_CONTEXT_SECONDS,
             "fresh": {
-                "audio_b64": _to_wav_b64(fresh_audio, fresh_sr),
+                "audio_b64": _to_wav_b64(fresh_compare_audio, fresh_sr),
                 "sample_rate": fresh_sr,
                 "metrics": {
                     "total_ms": round(fresh_elapsed * 1000),
@@ -901,7 +954,7 @@ async def generate_continuation_compare(
                 },
             },
             "continued": {
-                "audio_b64": _to_wav_b64(cont_audio, cont_sr),
+                "audio_b64": _to_wav_b64(cont_compare_audio, cont_sr),
                 "sample_rate": cont_sr,
                 "metrics": {
                     "total_ms": round(cont_elapsed * 1000),

--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -4,5 +4,5 @@ faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 from .continuation import apply_continuation_state_delta
 from .model import FasterQwen3TTS
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 __all__ = ["FasterQwen3TTS", "apply_continuation_state_delta"]

--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -1,7 +1,8 @@
 """
 faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 """
+from .continuation import apply_continuation_state_delta
 from .model import FasterQwen3TTS
 
 __version__ = "0.2.6"
-__all__ = ["FasterQwen3TTS"]
+__all__ = ["FasterQwen3TTS", "apply_continuation_state_delta"]

--- a/faster_qwen3_tts/continuation.py
+++ b/faster_qwen3_tts/continuation.py
@@ -32,6 +32,18 @@ def model_signature(*, num_layers: int, max_seq_len: int, hidden_size: int) -> D
     }
 
 
+def _validate_cache_layer_count(
+    *,
+    cache_layers: Any,
+    expected_num_layers: int,
+    field_name: str,
+) -> None:
+    if len(cache_layers) != expected_num_layers:
+        raise ValueError(
+            f"{field_name} layer count mismatch: expected {expected_num_layers}, got {len(cache_layers)}"
+        )
+
+
 def build_continuation_state_status(*, seq_len: int, max_seq_len: int) -> Dict[str, Any]:
     usable_seq_len = max(int(max_seq_len) - 1, 0)
     remaining_tokens = max(usable_seq_len - int(seq_len), 0)
@@ -81,6 +93,38 @@ def validate_full_continuation_state(
         )
     if state.get("model_signature") != expected_signature:
         raise ValueError("continuation_state does not match the loaded model configuration")
+    _validate_cache_layer_count(
+        cache_layers=state.get("cache", []),
+        expected_num_layers=expected_signature["num_layers"],
+        field_name="continuation_state.cache",
+    )
+
+
+def validate_continuation_delta(delta: Dict[str, Any]) -> None:
+    if delta.get("version") != CONTINUATION_STATE_VERSION:
+        raise ValueError(
+            f"Unsupported continuation delta version: {delta.get('version')!r}"
+        )
+    if delta.get("state_kind") == "full":
+        signature = delta.get("model_signature")
+        if not isinstance(signature, dict):
+            raise ValueError("Full continuation state is missing model_signature")
+        _validate_cache_layer_count(
+            cache_layers=delta.get("cache", []),
+            expected_num_layers=int(signature["num_layers"]),
+            field_name="continuation_state.cache",
+        )
+        return
+    if delta.get("state_kind") != "delta":
+        raise ValueError("Unknown continuation state kind")
+    signature = delta.get("model_signature")
+    if not isinstance(signature, dict):
+        raise ValueError("Continuation delta is missing model_signature")
+    _validate_cache_layer_count(
+        cache_layers=delta.get("cache_delta", []),
+        expected_num_layers=int(signature["num_layers"]),
+        field_name="continuation_state_delta.cache_delta",
+    )
 
 
 def continuation_state_to_dynamic_cache(
@@ -326,14 +370,9 @@ def apply_continuation_state_delta(
     state: Optional[Dict[str, Any]],
     delta: Dict[str, Any],
 ) -> Dict[str, Any]:
-    if delta.get("version") != CONTINUATION_STATE_VERSION:
-        raise ValueError(
-            f"Unsupported continuation delta version: {delta.get('version')!r}"
-        )
+    validate_continuation_delta(delta)
     if delta.get("state_kind") == "full":
         return delta
-    if delta.get("state_kind") != "delta":
-        raise ValueError("Unknown continuation state kind")
 
     if state is None:
         if int(delta["base_seq_len"]) != 0:

--- a/faster_qwen3_tts/continuation.py
+++ b/faster_qwen3_tts/continuation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, Tuple
 
 import torch
 from transformers.cache_utils import DynamicCache
@@ -35,6 +35,8 @@ def model_signature(*, num_layers: int, max_seq_len: int, hidden_size: int) -> D
 def build_continuation_state_status(*, seq_len: int, max_seq_len: int) -> Dict[str, Any]:
     usable_seq_len = max(int(max_seq_len) - 1, 0)
     remaining_tokens = max(usable_seq_len - int(seq_len), 0)
+    # Warn once the session is down to roughly the larger of 64 tokens or 12.5%
+    # of the cache. That gives callers room to reset before they hard-fail.
     warning_threshold_tokens = max(CONTINUATION_WARNING_MIN_TOKENS, usable_seq_len // 8)
     should_reset = remaining_tokens <= warning_threshold_tokens
 
@@ -122,14 +124,14 @@ def continuation_state_decoder_context(
 
 
 def export_static_cache_slice(
-    static_cache,
+    cache_source,
     *,
     start_pos: int,
     end_pos: int,
     device: str,
 ) -> list[Dict[str, torch.Tensor]]:
     layers = []
-    for layer in static_cache.layers:
+    for layer in cache_source.layers:
         layers.append(
             {
                 "key": layer.keys[:, :, start_pos:end_pos, :].clone().to(device),
@@ -141,7 +143,7 @@ def export_static_cache_slice(
 
 def build_continuation_state_delta(
     *,
-    static_cache,
+    cache_source,
     base_seq_len: int,
     seq_len: int,
     rope_deltas: Optional[torch.Tensor],
@@ -176,7 +178,7 @@ def build_continuation_state_delta(
         "seq_len": int(seq_len),
         "added_seq_len": int(seq_len - base_seq_len),
         "cache_delta": export_static_cache_slice(
-            static_cache,
+            cache_source,
             start_pos=base_seq_len,
             end_pos=seq_len,
             device=device,
@@ -190,18 +192,134 @@ def build_continuation_state_delta(
 def _decoder_context_from_delta(
     base_context: Optional[torch.Tensor],
     delta_codes: torch.Tensor,
-) -> torch.Tensor:
+) -> Optional[torch.Tensor]:
     pieces = []
     if base_context is not None and base_context.numel() > 0:
         pieces.append(base_context)
     if delta_codes.numel() > 0:
         pieces.append(delta_codes)
     if not pieces:
-        return torch.empty(0, 0, dtype=torch.long)
+        return None
     merged = torch.cat(pieces, dim=0)
     if merged.shape[0] > DECODER_CONTEXT_FRAMES:
         merged = merged[-DECODER_CONTEXT_FRAMES:]
     return merged
+
+
+def prefill_with_continuation(
+    *,
+    talker,
+    talker_input_embeds: torch.Tensor,
+    attention_mask: torch.Tensor,
+    trailing_text_hiddens: torch.Tensor,
+    tts_pad_embed: torch.Tensor,
+    continuation_state: Optional[Dict[str, Any]],
+    max_seq_len: int,
+    device: torch.device | str,
+) -> Tuple[Any, torch.Tensor, int]:
+    """Run talker prefill with or without an existing continuation cache."""
+    base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
+    full_attention_mask = attention_mask
+    if continuation_state is None:
+        out = talker.forward(
+            inputs_embeds=talker_input_embeds,
+            attention_mask=attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=None,
+        )
+        return out, full_attention_mask, base_seq_len
+
+    prefix_len = int(talker_input_embeds.shape[1])
+    required_len = base_seq_len + prefix_len
+    if required_len >= max_seq_len - 1:
+        raise RuntimeError(
+            "Continuation prefill exceeds max_seq_len. Reset the continuation state "
+            "or increase max_seq_len."
+        )
+    full_attention_mask = torch.ones(
+        attention_mask.shape[0],
+        required_len,
+        dtype=attention_mask.dtype,
+        device=attention_mask.device,
+    )
+    prefix_cache_position = torch.arange(base_seq_len, required_len, device=device)
+    prefix_input_ids = torch.zeros(
+        (talker_input_embeds.shape[0], prefix_len),
+        dtype=torch.long,
+        device=device,
+    )
+    talker.rope_deltas = continuation_state["rope_deltas"].to(
+        device=talker_input_embeds.device,
+        dtype=torch.float32,
+    )
+    past_key_values = continuation_state_to_dynamic_cache(
+        continuation_state,
+        config=talker.config,
+        device=device,
+    )
+    out = talker.forward(
+        input_ids=prefix_input_ids,
+        inputs_embeds=talker_input_embeds,
+        attention_mask=full_attention_mask,
+        use_cache=True,
+        output_hidden_states=True,
+        return_dict=True,
+        trailing_text_hidden=trailing_text_hiddens,
+        tts_pad_embed=tts_pad_embed,
+        generation_step=None,
+        past_hidden=None,
+        past_key_values=past_key_values,
+        cache_position=prefix_cache_position,
+    )
+    return out, full_attention_mask, base_seq_len
+
+
+def attach_continuation_result(
+    *,
+    timing: Dict[str, Any],
+    continuation_return_mode: ReturnContinuationMode,
+    running_state: Optional[Dict[str, Any]],
+    cache_source,
+    base_seq_len: int,
+    seq_len: int,
+    rope_deltas: Optional[torch.Tensor],
+    first_codebook_history_delta: list[torch.Tensor],
+    codec_ids_delta: list[torch.Tensor],
+    mode: str,
+    non_streaming_mode: bool,
+    model_signature_dict: Dict[str, int],
+    device: str,
+    max_seq_len: int,
+) -> Optional[Dict[str, Any]]:
+    """Attach delta/full continuation metadata to a timing dict."""
+    delta = build_continuation_state_delta(
+        cache_source=cache_source,
+        base_seq_len=base_seq_len,
+        seq_len=seq_len,
+        rope_deltas=rope_deltas,
+        first_codebook_history_delta=first_codebook_history_delta,
+        codec_ids_delta=codec_ids_delta,
+        mode=mode,
+        non_streaming_mode=non_streaming_mode,
+        model_signature_dict=model_signature_dict,
+        device=device,
+    )
+    if continuation_return_mode == "delta":
+        timing["continuation_state_delta"] = delta
+    else:
+        running_state = apply_continuation_state_delta(running_state, delta)
+        timing["continuation_state"] = running_state
+    timing["continuation_state_status"] = build_continuation_state_status(
+        seq_len=seq_len,
+        max_seq_len=max_seq_len,
+    )
+    return running_state
 
 
 def apply_continuation_state_delta(
@@ -218,6 +336,10 @@ def apply_continuation_state_delta(
         raise ValueError("Unknown continuation state kind")
 
     if state is None:
+        if int(delta["base_seq_len"]) != 0:
+            raise ValueError(
+                "Cannot build a full continuation state from a delta whose base_seq_len is non-zero"
+            )
         base_context = None
         cache = [
             {
@@ -227,6 +349,7 @@ def apply_continuation_state_delta(
             for layer in delta["cache_delta"]
         ]
         first_history = delta["first_codebook_history_delta"].clone()
+        rope_deltas = delta["rope_deltas"].clone().to(dtype=torch.float32)
     else:
         validate_full_continuation_state(
             state,
@@ -256,8 +379,17 @@ def apply_continuation_state_delta(
             dim=0,
         )
         base_context = state.get("decoder_context_codes")
+        rope_deltas = delta["rope_deltas"].to(
+            device=state["rope_deltas"].device,
+            dtype=state["rope_deltas"].dtype,
+        ).clone()
 
-    delta_codes = delta["codec_ids_delta"]
+    context_device = (
+        base_context.device
+        if base_context is not None
+        else first_history.device
+    )
+    delta_codes = delta["codec_ids_delta"].to(context_device)
     decoder_context = _decoder_context_from_delta(base_context, delta_codes)
 
     return {
@@ -268,7 +400,7 @@ def apply_continuation_state_delta(
         "model_signature": dict(delta["model_signature"]),
         "seq_len": int(delta["seq_len"]),
         "cache": cache,
-        "rope_deltas": delta["rope_deltas"].clone(),
+        "rope_deltas": rope_deltas,
         "first_codebook_history": first_history,
         "decoder_context_codes": decoder_context,
     }

--- a/faster_qwen3_tts/continuation.py
+++ b/faster_qwen3_tts/continuation.py
@@ -17,7 +17,7 @@ def normalize_return_continuation_state(value: bool | str | None) -> ReturnConti
         return "none"
     if value is True:
         return "delta"
-    if value not in {"delta", "full"}:
+    if value not in {"none", "delta", "full"}:
         raise ValueError(
             "return_continuation_state must be one of False, True, 'delta', or 'full'"
         )

--- a/faster_qwen3_tts/continuation.py
+++ b/faster_qwen3_tts/continuation.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional
+
+import torch
+from transformers.cache_utils import DynamicCache
+
+CONTINUATION_STATE_VERSION = 1
+DECODER_CONTEXT_FRAMES = 25
+CONTINUATION_WARNING_MIN_TOKENS = 64
+
+ReturnContinuationMode = Literal["none", "delta", "full"]
+
+
+def normalize_return_continuation_state(value: bool | str | None) -> ReturnContinuationMode:
+    if value in (None, False):
+        return "none"
+    if value is True:
+        return "delta"
+    if value not in {"delta", "full"}:
+        raise ValueError(
+            "return_continuation_state must be one of False, True, 'delta', or 'full'"
+        )
+    return value
+
+
+def model_signature(*, num_layers: int, max_seq_len: int, hidden_size: int) -> Dict[str, int]:
+    return {
+        "num_layers": int(num_layers),
+        "max_seq_len": int(max_seq_len),
+        "hidden_size": int(hidden_size),
+    }
+
+
+def build_continuation_state_status(*, seq_len: int, max_seq_len: int) -> Dict[str, Any]:
+    usable_seq_len = max(int(max_seq_len) - 1, 0)
+    remaining_tokens = max(usable_seq_len - int(seq_len), 0)
+    warning_threshold_tokens = max(CONTINUATION_WARNING_MIN_TOKENS, usable_seq_len // 8)
+    should_reset = remaining_tokens <= warning_threshold_tokens
+
+    status: Dict[str, Any] = {
+        "seq_len": int(seq_len),
+        "max_seq_len": int(max_seq_len),
+        "usable_seq_len": usable_seq_len,
+        "remaining_tokens": remaining_tokens,
+        "warning_threshold_tokens": warning_threshold_tokens,
+        "should_reset": should_reset,
+    }
+    if remaining_tokens == 0:
+        status["warning"] = (
+            "Continuation state has no remaining token budget. Start a fresh session "
+            "before the next turn."
+        )
+    elif should_reset:
+        status["warning"] = (
+            f"Continuation state is close to max_seq_len "
+            f"({remaining_tokens} tokens remaining). Start a fresh session soon."
+        )
+    return status
+
+
+def validate_full_continuation_state(
+    state: Optional[Dict[str, Any]],
+    *,
+    mode: str,
+    expected_signature: Dict[str, int],
+) -> None:
+    if state is None:
+        return
+    if state.get("version") != CONTINUATION_STATE_VERSION:
+        raise ValueError(
+            f"Unsupported continuation_state version: {state.get('version')!r}"
+        )
+    if state.get("state_kind") != "full":
+        raise ValueError("continuation_state must be a full state. Apply the delta first.")
+    if state.get("mode") != mode:
+        raise ValueError(
+            f"continuation_state mode mismatch: expected {mode!r}, got {state.get('mode')!r}"
+        )
+    if state.get("model_signature") != expected_signature:
+        raise ValueError("continuation_state does not match the loaded model configuration")
+
+
+def continuation_state_to_dynamic_cache(
+    state: Dict[str, Any],
+    *,
+    config,
+    device: str,
+) -> DynamicCache:
+    cache_entries = []
+    for layer in state["cache"]:
+        key = layer["key"].to(device)
+        value = layer["value"].to(device)
+        cache_entries.append((key, value))
+    return DynamicCache(ddp_cache_data=cache_entries, config=config)
+
+
+def continuation_state_first_token_history(
+    state: Optional[Dict[str, Any]],
+    *,
+    device: str,
+) -> list[torch.Tensor]:
+    if state is None:
+        return []
+    history = state.get("first_codebook_history")
+    if history is None or history.numel() == 0:
+        return []
+    return [tok.detach() for tok in history.to(device)]
+
+
+def continuation_state_decoder_context(
+    state: Optional[Dict[str, Any]],
+    *,
+    device: str,
+) -> Optional[torch.Tensor]:
+    if state is None:
+        return None
+    codes = state.get("decoder_context_codes")
+    if codes is None or codes.numel() == 0:
+        return None
+    return codes.to(device)
+
+
+def export_static_cache_slice(
+    static_cache,
+    *,
+    start_pos: int,
+    end_pos: int,
+    device: str,
+) -> list[Dict[str, torch.Tensor]]:
+    layers = []
+    for layer in static_cache.layers:
+        layers.append(
+            {
+                "key": layer.keys[:, :, start_pos:end_pos, :].clone().to(device),
+                "value": layer.values[:, :, start_pos:end_pos, :].clone().to(device),
+            }
+        )
+    return layers
+
+
+def build_continuation_state_delta(
+    *,
+    static_cache,
+    base_seq_len: int,
+    seq_len: int,
+    rope_deltas: Optional[torch.Tensor],
+    first_codebook_history_delta: list[torch.Tensor],
+    codec_ids_delta: list[torch.Tensor],
+    mode: str,
+    non_streaming_mode: bool,
+    model_signature_dict: Dict[str, int],
+    device: str,
+) -> Dict[str, Any]:
+    rope = (
+        torch.zeros(1, 1, dtype=torch.float32, device=device)
+        if rope_deltas is None
+        else rope_deltas.detach().clone().to(device=device, dtype=torch.float32)
+    )
+    if first_codebook_history_delta:
+        first_tokens = torch.stack(first_codebook_history_delta).to(device=device)
+    else:
+        first_tokens = torch.empty(0, dtype=torch.long, device=device)
+    if codec_ids_delta:
+        codec_delta = torch.stack(codec_ids_delta).to(device=device)
+    else:
+        codec_delta = torch.empty(0, 0, dtype=torch.long, device=device)
+
+    return {
+        "version": CONTINUATION_STATE_VERSION,
+        "state_kind": "delta",
+        "mode": mode,
+        "non_streaming_mode": bool(non_streaming_mode),
+        "model_signature": dict(model_signature_dict),
+        "base_seq_len": int(base_seq_len),
+        "seq_len": int(seq_len),
+        "added_seq_len": int(seq_len - base_seq_len),
+        "cache_delta": export_static_cache_slice(
+            static_cache,
+            start_pos=base_seq_len,
+            end_pos=seq_len,
+            device=device,
+        ),
+        "rope_deltas": rope,
+        "first_codebook_history_delta": first_tokens,
+        "codec_ids_delta": codec_delta,
+    }
+
+
+def _decoder_context_from_delta(
+    base_context: Optional[torch.Tensor],
+    delta_codes: torch.Tensor,
+) -> torch.Tensor:
+    pieces = []
+    if base_context is not None and base_context.numel() > 0:
+        pieces.append(base_context)
+    if delta_codes.numel() > 0:
+        pieces.append(delta_codes)
+    if not pieces:
+        return torch.empty(0, 0, dtype=torch.long)
+    merged = torch.cat(pieces, dim=0)
+    if merged.shape[0] > DECODER_CONTEXT_FRAMES:
+        merged = merged[-DECODER_CONTEXT_FRAMES:]
+    return merged
+
+
+def apply_continuation_state_delta(
+    state: Optional[Dict[str, Any]],
+    delta: Dict[str, Any],
+) -> Dict[str, Any]:
+    if delta.get("version") != CONTINUATION_STATE_VERSION:
+        raise ValueError(
+            f"Unsupported continuation delta version: {delta.get('version')!r}"
+        )
+    if delta.get("state_kind") == "full":
+        return delta
+    if delta.get("state_kind") != "delta":
+        raise ValueError("Unknown continuation state kind")
+
+    if state is None:
+        base_context = None
+        cache = [
+            {
+                "key": layer["key"].clone(),
+                "value": layer["value"].clone(),
+            }
+            for layer in delta["cache_delta"]
+        ]
+        first_history = delta["first_codebook_history_delta"].clone()
+    else:
+        validate_full_continuation_state(
+            state,
+            mode=delta["mode"],
+            expected_signature=delta["model_signature"],
+        )
+        if state["seq_len"] != delta["base_seq_len"]:
+            raise ValueError(
+                "continuation_state seq_len does not match the supplied delta base_seq_len"
+            )
+        cache = []
+        for existing, update in zip(state["cache"], delta["cache_delta"]):
+            cache.append(
+                {
+                    "key": torch.cat([existing["key"], update["key"].to(existing["key"].device)], dim=2),
+                    "value": torch.cat(
+                        [existing["value"], update["value"].to(existing["value"].device)],
+                        dim=2,
+                    ),
+                }
+            )
+        first_history = torch.cat(
+            [
+                state["first_codebook_history"],
+                delta["first_codebook_history_delta"].to(state["first_codebook_history"].device),
+            ],
+            dim=0,
+        )
+        base_context = state.get("decoder_context_codes")
+
+    delta_codes = delta["codec_ids_delta"]
+    decoder_context = _decoder_context_from_delta(base_context, delta_codes)
+
+    return {
+        "version": CONTINUATION_STATE_VERSION,
+        "state_kind": "full",
+        "mode": delta["mode"],
+        "non_streaming_mode": bool(delta["non_streaming_mode"]),
+        "model_signature": dict(delta["model_signature"]),
+        "seq_len": int(delta["seq_len"]),
+        "cache": cache,
+        "rope_deltas": delta["rope_deltas"].clone(),
+        "first_codebook_history": first_history,
+        "decoder_context_codes": decoder_context,
+    }

--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -58,23 +58,26 @@ def fast_generate(
     suppress_mask = build_suppress_mask(vocab_size, eos_id, device=device)
 
     continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
-    signature = model_signature(
-        num_layers=talker_graph.num_layers,
-        max_seq_len=talker_graph.max_seq_len,
-        hidden_size=talker_graph.hidden_size,
-    )
-    validate_full_continuation_state(
-        continuation_state,
-        mode=continuation_mode,
-        expected_signature=signature,
-    )
-    if (
-        continuation_state is not None
-        and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
-    ):
-        raise ValueError(
-            "continuation_state non_streaming_mode does not match the current request"
+    continuation_active = continuation_state is not None or continuation_return_mode != "none"
+    signature = None
+    if continuation_active:
+        signature = model_signature(
+            num_layers=talker_graph.num_layers,
+            max_seq_len=talker_graph.max_seq_len,
+            hidden_size=talker_graph.hidden_size,
         )
+        validate_full_continuation_state(
+            continuation_state,
+            mode=continuation_mode,
+            expected_signature=signature,
+        )
+        if (
+            continuation_state is not None
+            and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
+        ):
+            raise ValueError(
+                "continuation_state non_streaming_mode does not match the current request"
+            )
     base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
 
     if parity_mode:

--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -7,6 +7,16 @@ from typing import Optional, Tuple
 
 import torch
 
+from .continuation import (
+    apply_continuation_state_delta,
+    build_continuation_state_status,
+    build_continuation_state_delta,
+    continuation_state_first_token_history,
+    continuation_state_to_dynamic_cache,
+    model_signature,
+    normalize_return_continuation_state,
+    validate_full_continuation_state,
+)
 from .predictor_graph import PredictorGraph
 from .sampling import apply_repetition_penalty, sample_logits
 from .talker_graph import TalkerGraph
@@ -34,6 +44,11 @@ def fast_generate(
     subtalker_top_p: Optional[float] = None,
     subtalker_temperature: Optional[float] = None,
     parity_mode: bool = False,
+    continuation_state: Optional[dict] = None,
+    return_continuation_state: bool | str = False,
+    continuation_mode: str = "voice_clone",
+    continuation_non_streaming_mode: bool = False,
+    continuation_state_device: str = "cpu",
 ) -> Tuple[Optional[torch.Tensor], dict]:
     """
     Fast autoregressive generation with CUDA-graphed predictor and talker.
@@ -48,6 +63,26 @@ def fast_generate(
     for i in range(suppress_start, vocab_size):
         if i != eos_id:
             suppress_mask[i] = True
+
+    continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
+    signature = model_signature(
+        num_layers=talker_graph.num_layers,
+        max_seq_len=talker_graph.max_seq_len,
+        hidden_size=talker_graph.hidden_size,
+    )
+    validate_full_continuation_state(
+        continuation_state,
+        mode=continuation_mode,
+        expected_signature=signature,
+    )
+    if (
+        continuation_state is not None
+        and continuation_state["non_streaming_mode"] != bool(continuation_non_streaming_mode)
+    ):
+        raise ValueError(
+            "continuation_state non_streaming_mode does not match the current request"
+        )
+    base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
 
     if parity_mode:
         suppress_tokens = [i for i in range(suppress_start, vocab_size) if i != eos_id]
@@ -103,19 +138,67 @@ def fast_generate(
     
     # === PREFILL (still uses HF forward for variable-length prefill) ===
     t_start = time.time()
-    
-    out = talker.forward(
-        inputs_embeds=talker_input_embeds,
-        attention_mask=attention_mask,
-        use_cache=True,
-        output_hidden_states=True,
-        return_dict=True,
-        trailing_text_hidden=trailing_text_hiddens,
-        tts_pad_embed=tts_pad_embed,
-        generation_step=None,
-        past_hidden=None,
-        past_key_values=None,
-    )
+    full_attention_mask = attention_mask
+    if continuation_state is None:
+        out = talker.forward(
+            inputs_embeds=talker_input_embeds,
+            attention_mask=attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=None,
+        )
+    else:
+        prefix_len = int(talker_input_embeds.shape[1])
+        required_len = base_seq_len + prefix_len
+        if required_len >= talker_graph.max_seq_len - 1:
+            raise RuntimeError(
+                "Continuation prefill exceeds max_seq_len. Reset the continuation state "
+                "or increase max_seq_len."
+            )
+        full_attention_mask = torch.ones(
+            attention_mask.shape[0],
+            required_len,
+            dtype=attention_mask.dtype,
+            device=attention_mask.device,
+        )
+        prefix_cache_position = torch.arange(
+            base_seq_len,
+            required_len,
+            device=device,
+        )
+        prefix_input_ids = torch.zeros(
+            (talker_input_embeds.shape[0], prefix_len),
+            dtype=torch.long,
+            device=device,
+        )
+        talker.rope_deltas = continuation_state["rope_deltas"].to(
+            device=talker_input_embeds.device,
+            dtype=torch.float32,
+        )
+        dynamic_cache = continuation_state_to_dynamic_cache(
+            continuation_state,
+            config=talker.config,
+            device=device,
+        )
+        out = talker.forward(
+            input_ids=prefix_input_ids,
+            inputs_embeds=talker_input_embeds,
+            attention_mask=full_attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=dynamic_cache,
+            cache_position=prefix_cache_position,
+        )
     
     talker_past_kv = out.past_key_values
     past_hidden = out.past_hidden
@@ -137,7 +220,7 @@ def fast_generate(
     prefill_len = talker_graph.prefill_kv(talker_past_kv)
     # Sync padding mask + rope deltas for decode parity
     rope_deltas = getattr(talker, "rope_deltas", None)
-    talker_graph.set_generation_state(attention_mask, rope_deltas)
+    talker_graph.set_generation_state(full_attention_mask, rope_deltas)
     
     torch.cuda.synchronize()
     t_prefill = time.time() - t_start
@@ -145,6 +228,11 @@ def fast_generate(
     # === DECODE LOOP ===
     t_decode_start = time.time()
     all_codec_ids = []
+    all_first_tokens = continuation_state_first_token_history(
+        continuation_state,
+        device=device,
+    )
+    generated_first_tokens = []
     
     for step_idx in range(max_new_tokens):
         if token.item() == eos_id:
@@ -158,6 +246,8 @@ def fast_generate(
         # Build full codec: [first_cb, cb1, ..., cb15]
         all_cb = torch.cat([token.view(1), codebook_token_ids])  # [16]
         all_codec_ids.append(all_cb.detach())
+        all_first_tokens.append(token.detach())
+        generated_first_tokens.append(token.detach())
         
         # --- Build input embedding for talker ---
         codec_hiddens = [last_id_hidden]
@@ -181,8 +271,8 @@ def fast_generate(
         
         logits = talker_codec_head(hidden_states[:, -1, :]).unsqueeze(0)
         
-        if repetition_penalty != 1.0 and len(all_codec_ids) > 0:
-            history = torch.stack([c[0] for c in all_codec_ids])
+        if repetition_penalty != 1.0 and all_first_tokens:
+            history = torch.stack(all_first_tokens)
             logits = apply_repetition_penalty(logits, history, repetition_penalty)
 
         suppress_eos = len(all_codec_ids) < min_new_tokens
@@ -209,6 +299,31 @@ def fast_generate(
         'ms_per_step': (t_decode / n_steps * 1000) if n_steps > 0 else 0,
         'steps_per_s': (n_steps / t_decode) if t_decode > 0 else 0,
     }
+    if continuation_return_mode != "none":
+        final_seq_len = prefill_len + n_steps
+        delta = build_continuation_state_delta(
+            static_cache=talker_graph.static_cache,
+            base_seq_len=base_seq_len,
+            seq_len=final_seq_len,
+            rope_deltas=talker_graph.rope_deltas,
+            first_codebook_history_delta=generated_first_tokens,
+            codec_ids_delta=all_codec_ids,
+            mode=continuation_mode,
+            non_streaming_mode=continuation_non_streaming_mode,
+            model_signature_dict=signature,
+            device=continuation_state_device,
+        )
+        if continuation_return_mode == "delta":
+            timing["continuation_state_delta"] = delta
+        else:
+            timing["continuation_state"] = apply_continuation_state_delta(
+                continuation_state,
+                delta,
+            )
+        timing["continuation_state_status"] = build_continuation_state_status(
+            seq_len=final_seq_len,
+            max_seq_len=talker_graph.max_seq_len,
+        )
     
     if all_codec_ids:
         return torch.stack(all_codec_ids), timing

--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -8,17 +8,15 @@ from typing import Optional, Tuple
 import torch
 
 from .continuation import (
-    apply_continuation_state_delta,
-    build_continuation_state_status,
-    build_continuation_state_delta,
+    attach_continuation_result,
     continuation_state_first_token_history,
-    continuation_state_to_dynamic_cache,
     model_signature,
     normalize_return_continuation_state,
+    prefill_with_continuation,
     validate_full_continuation_state,
 )
 from .predictor_graph import PredictorGraph
-from .sampling import apply_repetition_penalty, sample_logits
+from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
 
 
@@ -57,12 +55,7 @@ def fast_generate(
     num_code_groups = config.num_code_groups
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
-    
-    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
-    suppress_start = max(0, vocab_size - 1024)
-    for i in range(suppress_start, vocab_size):
-        if i != eos_id:
-            suppress_mask[i] = True
+    suppress_mask = build_suppress_mask(vocab_size, eos_id, device=device)
 
     continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
     signature = model_signature(
@@ -77,7 +70,7 @@ def fast_generate(
     )
     if (
         continuation_state is not None
-        and continuation_state["non_streaming_mode"] != bool(continuation_non_streaming_mode)
+        and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
     ):
         raise ValueError(
             "continuation_state non_streaming_mode does not match the current request"
@@ -85,7 +78,7 @@ def fast_generate(
     base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
 
     if parity_mode:
-        suppress_tokens = [i for i in range(suppress_start, vocab_size) if i != eos_id]
+        suppress_tokens = torch.nonzero(suppress_mask, as_tuple=False).flatten().tolist()
         t_start = time.time()
         talker_result = talker.generate(
             inputs_embeds=talker_input_embeds,
@@ -138,67 +131,16 @@ def fast_generate(
     
     # === PREFILL (still uses HF forward for variable-length prefill) ===
     t_start = time.time()
-    full_attention_mask = attention_mask
-    if continuation_state is None:
-        out = talker.forward(
-            inputs_embeds=talker_input_embeds,
-            attention_mask=attention_mask,
-            use_cache=True,
-            output_hidden_states=True,
-            return_dict=True,
-            trailing_text_hidden=trailing_text_hiddens,
-            tts_pad_embed=tts_pad_embed,
-            generation_step=None,
-            past_hidden=None,
-            past_key_values=None,
-        )
-    else:
-        prefix_len = int(talker_input_embeds.shape[1])
-        required_len = base_seq_len + prefix_len
-        if required_len >= talker_graph.max_seq_len - 1:
-            raise RuntimeError(
-                "Continuation prefill exceeds max_seq_len. Reset the continuation state "
-                "or increase max_seq_len."
-            )
-        full_attention_mask = torch.ones(
-            attention_mask.shape[0],
-            required_len,
-            dtype=attention_mask.dtype,
-            device=attention_mask.device,
-        )
-        prefix_cache_position = torch.arange(
-            base_seq_len,
-            required_len,
-            device=device,
-        )
-        prefix_input_ids = torch.zeros(
-            (talker_input_embeds.shape[0], prefix_len),
-            dtype=torch.long,
-            device=device,
-        )
-        talker.rope_deltas = continuation_state["rope_deltas"].to(
-            device=talker_input_embeds.device,
-            dtype=torch.float32,
-        )
-        dynamic_cache = continuation_state_to_dynamic_cache(
-            continuation_state,
-            config=talker.config,
-            device=device,
-        )
-        out = talker.forward(
-            input_ids=prefix_input_ids,
-            inputs_embeds=talker_input_embeds,
-            attention_mask=full_attention_mask,
-            use_cache=True,
-            output_hidden_states=True,
-            return_dict=True,
-            trailing_text_hidden=trailing_text_hiddens,
-            tts_pad_embed=tts_pad_embed,
-            generation_step=None,
-            past_hidden=None,
-            past_key_values=dynamic_cache,
-            cache_position=prefix_cache_position,
-        )
+    out, full_attention_mask, base_seq_len = prefill_with_continuation(
+        talker=talker,
+        talker_input_embeds=talker_input_embeds,
+        attention_mask=attention_mask,
+        trailing_text_hiddens=trailing_text_hiddens,
+        tts_pad_embed=tts_pad_embed,
+        continuation_state=continuation_state,
+        max_seq_len=talker_graph.max_seq_len,
+        device=device,
+    )
     
     talker_past_kv = out.past_key_values
     past_hidden = out.past_hidden
@@ -301,8 +243,11 @@ def fast_generate(
     }
     if continuation_return_mode != "none":
         final_seq_len = prefill_len + n_steps
-        delta = build_continuation_state_delta(
-            static_cache=talker_graph.static_cache,
+        attach_continuation_result(
+            timing=timing,
+            continuation_return_mode=continuation_return_mode,
+            running_state=continuation_state,
+            cache_source=talker_graph.static_cache,
             base_seq_len=base_seq_len,
             seq_len=final_seq_len,
             rope_deltas=talker_graph.rope_deltas,
@@ -312,16 +257,6 @@ def fast_generate(
             non_streaming_mode=continuation_non_streaming_mode,
             model_signature_dict=signature,
             device=continuation_state_device,
-        )
-        if continuation_return_mode == "delta":
-            timing["continuation_state_delta"] = delta
-        else:
-            timing["continuation_state"] = apply_continuation_state_delta(
-                continuation_state,
-                delta,
-            )
-        timing["continuation_state_status"] = build_continuation_state_status(
-            seq_len=final_seq_len,
             max_seq_len=talker_graph.max_seq_len,
         )
     

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -12,6 +12,10 @@ import numpy as np
 import soundfile as sf
 import torch
 
+from .continuation import (
+    continuation_state_decoder_context,
+    normalize_return_continuation_state,
+)
 from .utils import suppress_flash_attn_warning
 
 logger = logging.getLogger(__name__)
@@ -89,6 +93,20 @@ class FasterQwen3TTS:
     ) -> bool:
         """Treat None as the method-specific upstream default."""
         return default if non_streaming_mode is None else non_streaming_mode
+
+    @staticmethod
+    def _build_generation_info(timing: dict, rtf: float) -> Dict[str, Any]:
+        info: Dict[str, Any] = {
+            "timing": timing,
+            "rtf": rtf,
+        }
+        if "continuation_state_delta" in timing:
+            info["continuation_state_delta"] = timing["continuation_state_delta"]
+        if "continuation_state" in timing:
+            info["continuation_state"] = timing["continuation_state"]
+        if "continuation_state_status" in timing:
+            info["continuation_state_status"] = timing["continuation_state_status"]
+        return info
         
     @classmethod
     def from_pretrained(
@@ -752,7 +770,10 @@ class FasterQwen3TTS:
         append_silence: bool = True,
         instruct: Optional[str] = None,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
-    ) -> Tuple[list, int]:
+        continuation_state: Optional[Dict[str, Any]] = None,
+        return_continuation_state: bool | str = False,
+        continuation_state_device: str = "cpu",
+    ) -> Union[Tuple[list, int], Tuple[list, int, Dict[str, Any]]]:
         """
         Generate speech with voice cloning using reference audio.
 
@@ -783,11 +804,20 @@ class FasterQwen3TTS:
             instruct: Optional instruction to guide generation style/dialect (e.g.
                 "请用纯正广东话朗读"). Prepended as a user turn before the TTS assistant turn.
                 Experimental for x-vector-only voice cloning; prefer `xvec_only=False`.
+            continuation_state: Optional full continuation state returned by a prior
+                generation call. When supplied, the new sentence is prefixed onto the
+                existing talker cache instead of starting from an empty cache.
+            return_continuation_state: When `True`/`"delta"`, include a continuation
+                delta in the returned info dict. Use `"full"` to return the merged full
+                state instead.
+            continuation_state_device: Device for returned continuation tensors.
 
         Returns:
-            Tuple of ([audio_waveform], sample_rate)
+            Tuple of ([audio_waveform], sample_rate), plus an info dict when
+            `return_continuation_state` is enabled.
         """
         from .generate import fast_generate
+        continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
 
         non_streaming_mode = self._resolve_non_streaming_mode(
             non_streaming_mode,
@@ -822,24 +852,37 @@ class FasterQwen3TTS:
             top_p=top_p,
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
+            continuation_state=continuation_state,
+            return_continuation_state=continuation_return_mode,
+            continuation_mode="voice_clone",
+            continuation_non_streaming_mode=non_streaming_mode,
+            continuation_state_device=continuation_state_device,
         )
 
         if codec_ids is None:
             logger.warning("Generation returned no tokens")
-            return [np.zeros(1, dtype=np.float32)], self.sample_rate
+            audio_arrays = [np.zeros(1, dtype=np.float32)]
+            if continuation_return_mode == "none":
+                return audio_arrays, self.sample_rate
+            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
 
         # In ICL mode: prepend reference codes before decoding so the codec decoder
         # has acoustic context from the reference audio (matches official implementation).
         speech_tokenizer = m.speech_tokenizer
-        if ref_codes is not None:
-            ref_codes_dev = ref_codes.to(codec_ids.device)
-            codes_for_decode = torch.cat([ref_codes_dev, codec_ids], dim=0)
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=codec_ids.device,
+        )
+        if decoder_prefix_codes is None and ref_codes is not None:
+            decoder_prefix_codes = ref_codes.to(codec_ids.device)
+        if decoder_prefix_codes is not None:
+            codes_for_decode = torch.cat([decoder_prefix_codes, codec_ids], dim=0)
         else:
             codes_for_decode = codec_ids
         audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
 
         # Convert to numpy and trim off the reference audio portion
-        ref_len = ref_codes.shape[0] if ref_codes is not None else 0
+        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
         total_len = codes_for_decode.shape[0]
         audio_arrays = []
         for a in audio_list:
@@ -861,8 +904,10 @@ class FasterQwen3TTS:
             f"Generated {audio_duration:.2f}s audio in {total_time:.2f}s "
             f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
         )
-        
-        return audio_arrays, sr
+
+        if continuation_return_mode == "none":
+            return audio_arrays, sr
+        return audio_arrays, sr, self._build_generation_info(timing, rtf)
 
     @torch.inference_mode()
     def generate_voice_clone_streaming(
@@ -885,6 +930,9 @@ class FasterQwen3TTS:
         parity_mode: bool = False,
         instruct: Optional[str] = None,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
+        continuation_state: Optional[Dict[str, Any]] = None,
+        return_continuation_state: bool | str = False,
+        continuation_state_device: str = "cpu",
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         """
         Stream voice-cloned speech generation, yielding audio chunks.
@@ -921,6 +969,11 @@ class FasterQwen3TTS:
             instruct: Optional instruction to guide generation style/dialect (e.g.
                 "请用纯正广东话朗读"). Prepended as a user turn before the TTS assistant turn.
                 Experimental for x-vector-only voice cloning; prefer `xvec_only=False`.
+            continuation_state: Optional full continuation state returned by a prior
+                generation call.
+            return_continuation_state: When enabled, include continuation deltas (or
+                full states) inside the yielded timing dict.
+            continuation_state_device: Device for returned continuation tensors.
 
         Yields:
             Tuple of (audio_chunk_numpy, sample_rate, timing_dict)
@@ -972,10 +1025,24 @@ class FasterQwen3TTS:
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
             chunk_size=chunk_size,
+            continuation_state=continuation_state,
+            return_continuation_state=return_continuation_state,
+            continuation_mode="voice_clone",
+            continuation_non_streaming_mode=non_streaming_mode,
+            continuation_state_device=continuation_state_device,
         )
         if not parity_mode:
             stream_kwargs["predictor_graph"] = self.predictor_graph
             stream_kwargs["talker_graph"] = self.talker_graph
+        else:
+            stream_kwargs["continuation_max_seq_len"] = self.max_seq_len
+
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=tie.device,
+        )
+        if decoder_prefix_codes is None and ref_codes is not None:
+            decoder_prefix_codes = ref_codes.to(tie.device)
 
         for codec_chunk, timing in stream_fn(**stream_kwargs):
             all_codes.append(codec_chunk)
@@ -987,8 +1054,8 @@ class FasterQwen3TTS:
                 # Phase 1: accumulated decode until we can calibrate.
                 # In ICL mode prepend reference codes so the codec decoder has acoustic
                 # context from the reference audio (matches official implementation).
-                if ref_codes is not None:
-                    codes_input = torch.cat([ref_codes.to(all_flat.device), all_flat], dim=0)
+                if decoder_prefix_codes is not None:
+                    codes_input = torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
                 else:
                     codes_input = all_flat
                 audio_list, sr = speech_tokenizer.decode(
@@ -1001,8 +1068,8 @@ class FasterQwen3TTS:
                     audio = audio.flatten() if hasattr(audio, 'flatten') else audio
 
                 # Separate out reference audio portion; track position in generated audio only
-                if ref_codes is not None:
-                    ref_len = ref_codes.shape[0]
+                if decoder_prefix_codes is not None:
+                    ref_len = decoder_prefix_codes.shape[0]
                     total_len = codes_input.shape[0]
                     ref_audio_cut = int(ref_len / max(total_len, 1) * len(audio))
                     gen_audio = audio[ref_audio_cut:]
@@ -1018,6 +1085,8 @@ class FasterQwen3TTS:
                 # Phase 2: sliding window with left context
                 ctx_start = max(0, n_total - n_new - context_frames)
                 window = all_flat[ctx_start:]
+                if ctx_start == 0 and decoder_prefix_codes is not None:
+                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
                 n_ctx = window.shape[0] - n_new
 
                 audio_list, sr = speech_tokenizer.decode(
@@ -1052,7 +1121,10 @@ class FasterQwen3TTS:
         top_p: float = 1.0,
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
-    ) -> Tuple[list, int]:
+        continuation_state: Optional[Dict[str, Any]] = None,
+        return_continuation_state: bool | str = False,
+        continuation_state_device: str = "cpu",
+    ) -> Union[Tuple[list, int], Tuple[list, int, Dict[str, Any]]]:
         if self.model.model.tts_model_type != "custom_voice":
             raise ValueError("Loaded model does not support custom voice generation")
 
@@ -1068,6 +1140,7 @@ class FasterQwen3TTS:
             instruct = None
 
         from .generate import fast_generate
+        continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
 
         m, talker, config, tie, tam, tth, tpe = self._prepare_generation_custom(
             text=text,
@@ -1093,21 +1166,43 @@ class FasterQwen3TTS:
             top_p=top_p,
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
+            continuation_state=continuation_state,
+            return_continuation_state=continuation_return_mode,
+            continuation_mode="custom_voice",
+            continuation_non_streaming_mode=non_streaming_mode,
+            continuation_state_device=continuation_state_device,
         )
 
         if codec_ids is None:
             logger.warning("Generation returned no tokens")
-            return [np.zeros(1, dtype=np.float32)], self.sample_rate
+            audio_arrays = [np.zeros(1, dtype=np.float32)]
+            if continuation_return_mode == "none":
+                return audio_arrays, self.sample_rate
+            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
 
         speech_tokenizer = m.speech_tokenizer
-        audio_list, sr = speech_tokenizer.decode({"audio_codes": codec_ids.unsqueeze(0)})
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=codec_ids.device,
+        )
+        if decoder_prefix_codes is not None:
+            codes_for_decode = torch.cat([decoder_prefix_codes, codec_ids], dim=0)
+        else:
+            codes_for_decode = codec_ids
+        audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
 
         audio_arrays = []
+        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
+        total_len = codes_for_decode.shape[0]
         for a in audio_list:
             if hasattr(a, "cpu"):
-                audio_arrays.append(a.flatten().cpu().numpy())
+                a = a.flatten().cpu().numpy()
             else:
-                audio_arrays.append(a.flatten() if hasattr(a, "flatten") else a)
+                a = a.flatten() if hasattr(a, "flatten") else a
+            if ref_len > 0:
+                cut = int(ref_len / max(total_len, 1) * len(a))
+                a = a[cut:]
+            audio_arrays.append(a)
 
         n_steps = timing["steps"]
         audio_duration = n_steps / 12.0
@@ -1119,7 +1214,9 @@ class FasterQwen3TTS:
             f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
         )
 
-        return audio_arrays, sr
+        if continuation_return_mode == "none":
+            return audio_arrays, sr
+        return audio_arrays, sr, self._build_generation_info(timing, rtf)
 
     @torch.inference_mode()
     def generate_custom_voice_streaming(
@@ -1137,6 +1234,9 @@ class FasterQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        continuation_state: Optional[Dict[str, Any]] = None,
+        return_continuation_state: bool | str = False,
+        continuation_state_device: str = "cpu",
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         if self.model.model.tts_model_type != "custom_voice":
             raise ValueError("Loaded model does not support custom voice generation")
@@ -1169,6 +1269,10 @@ class FasterQwen3TTS:
         all_codes = []
         prev_audio_len = 0
         samples_per_frame = None
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=tie.device,
+        )
 
         for codec_chunk, timing in fast_generate_streaming(
             talker=talker,
@@ -1187,6 +1291,11 @@ class FasterQwen3TTS:
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
             chunk_size=chunk_size,
+            continuation_state=continuation_state,
+            return_continuation_state=return_continuation_state,
+            continuation_mode="custom_voice",
+            continuation_non_streaming_mode=non_streaming_mode,
+            continuation_state_device=continuation_state_device,
         ):
             all_codes.append(codec_chunk)
             n_new = codec_chunk.shape[0]
@@ -1194,21 +1303,34 @@ class FasterQwen3TTS:
             n_total = all_flat.shape[0]
 
             if samples_per_frame is None:
-                audio_list, sr = speech_tokenizer.decode({"audio_codes": all_flat.unsqueeze(0)})
+                codes_input = (
+                    torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
+                    if decoder_prefix_codes is not None
+                    else all_flat
+                )
+                audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_input.unsqueeze(0)})
                 audio = audio_list[0]
                 if hasattr(audio, "cpu"):
                     audio = audio.flatten().cpu().numpy()
                 else:
                     audio = audio.flatten() if hasattr(audio, "flatten") else audio
 
-                new_audio = audio[prev_audio_len:]
-                prev_audio_len = len(audio)
+                if decoder_prefix_codes is not None:
+                    ref_len = decoder_prefix_codes.shape[0]
+                    ref_audio_cut = int(ref_len / max(codes_input.shape[0], 1) * len(audio))
+                    gen_audio = audio[ref_audio_cut:]
+                else:
+                    gen_audio = audio
+                new_audio = gen_audio[prev_audio_len:]
+                prev_audio_len = len(gen_audio)
 
                 if n_total >= min_calibration_frames:
-                    samples_per_frame = len(audio) / n_total
+                    samples_per_frame = len(gen_audio) / n_total
             else:
                 ctx_start = max(0, n_total - n_new - context_frames)
                 window = all_flat[ctx_start:]
+                if ctx_start == 0 and decoder_prefix_codes is not None:
+                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
                 n_ctx = window.shape[0] - n_new
 
                 audio_list, sr = speech_tokenizer.decode({"audio_codes": window.unsqueeze(0)})
@@ -1240,7 +1362,10 @@ class FasterQwen3TTS:
         top_p: float = 1.0,
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
-    ) -> Tuple[list, int]:
+        continuation_state: Optional[Dict[str, Any]] = None,
+        return_continuation_state: bool | str = False,
+        continuation_state_device: str = "cpu",
+    ) -> Union[Tuple[list, int], Tuple[list, int, Dict[str, Any]]]:
         if self.model.model.tts_model_type != "voice_design":
             raise ValueError("Loaded model does not support voice design generation")
 
@@ -1252,6 +1377,7 @@ class FasterQwen3TTS:
         )
 
         from .generate import fast_generate
+        continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
 
         m, talker, config, tie, tam, tth, tpe = self._prepare_generation_custom(
             text=text,
@@ -1277,21 +1403,43 @@ class FasterQwen3TTS:
             top_p=top_p,
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
+            continuation_state=continuation_state,
+            return_continuation_state=continuation_return_mode,
+            continuation_mode="voice_design",
+            continuation_non_streaming_mode=non_streaming_mode,
+            continuation_state_device=continuation_state_device,
         )
 
         if codec_ids is None:
             logger.warning("Generation returned no tokens")
-            return [np.zeros(1, dtype=np.float32)], self.sample_rate
+            audio_arrays = [np.zeros(1, dtype=np.float32)]
+            if continuation_return_mode == "none":
+                return audio_arrays, self.sample_rate
+            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
 
         speech_tokenizer = m.speech_tokenizer
-        audio_list, sr = speech_tokenizer.decode({"audio_codes": codec_ids.unsqueeze(0)})
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=codec_ids.device,
+        )
+        if decoder_prefix_codes is not None:
+            codes_for_decode = torch.cat([decoder_prefix_codes, codec_ids], dim=0)
+        else:
+            codes_for_decode = codec_ids
+        audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
 
         audio_arrays = []
+        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
+        total_len = codes_for_decode.shape[0]
         for a in audio_list:
             if hasattr(a, "cpu"):
-                audio_arrays.append(a.flatten().cpu().numpy())
+                a = a.flatten().cpu().numpy()
             else:
-                audio_arrays.append(a.flatten() if hasattr(a, "flatten") else a)
+                a = a.flatten() if hasattr(a, "flatten") else a
+            if ref_len > 0:
+                cut = int(ref_len / max(total_len, 1) * len(a))
+                a = a[cut:]
+            audio_arrays.append(a)
 
         n_steps = timing["steps"]
         audio_duration = n_steps / 12.0
@@ -1303,7 +1451,9 @@ class FasterQwen3TTS:
             f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
         )
 
-        return audio_arrays, sr
+        if continuation_return_mode == "none":
+            return audio_arrays, sr
+        return audio_arrays, sr, self._build_generation_info(timing, rtf)
 
     @torch.inference_mode()
     def generate_voice_design_streaming(
@@ -1320,6 +1470,9 @@ class FasterQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        continuation_state: Optional[Dict[str, Any]] = None,
+        return_continuation_state: bool | str = False,
+        continuation_state_device: str = "cpu",
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         if self.model.model.tts_model_type != "voice_design":
             raise ValueError("Loaded model does not support voice design generation")
@@ -1348,6 +1501,10 @@ class FasterQwen3TTS:
         all_codes = []
         prev_audio_len = 0
         samples_per_frame = None
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=tie.device,
+        )
 
         for codec_chunk, timing in fast_generate_streaming(
             talker=talker,
@@ -1366,6 +1523,11 @@ class FasterQwen3TTS:
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
             chunk_size=chunk_size,
+            continuation_state=continuation_state,
+            return_continuation_state=return_continuation_state,
+            continuation_mode="voice_design",
+            continuation_non_streaming_mode=non_streaming_mode,
+            continuation_state_device=continuation_state_device,
         ):
             all_codes.append(codec_chunk)
             n_new = codec_chunk.shape[0]
@@ -1373,21 +1535,34 @@ class FasterQwen3TTS:
             n_total = all_flat.shape[0]
 
             if samples_per_frame is None:
-                audio_list, sr = speech_tokenizer.decode({"audio_codes": all_flat.unsqueeze(0)})
+                codes_input = (
+                    torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
+                    if decoder_prefix_codes is not None
+                    else all_flat
+                )
+                audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_input.unsqueeze(0)})
                 audio = audio_list[0]
                 if hasattr(audio, "cpu"):
                     audio = audio.flatten().cpu().numpy()
                 else:
                     audio = audio.flatten() if hasattr(audio, "flatten") else audio
 
-                new_audio = audio[prev_audio_len:]
-                prev_audio_len = len(audio)
+                if decoder_prefix_codes is not None:
+                    ref_len = decoder_prefix_codes.shape[0]
+                    ref_audio_cut = int(ref_len / max(codes_input.shape[0], 1) * len(audio))
+                    gen_audio = audio[ref_audio_cut:]
+                else:
+                    gen_audio = audio
+                new_audio = gen_audio[prev_audio_len:]
+                prev_audio_len = len(gen_audio)
 
                 if n_total >= min_calibration_frames:
-                    samples_per_frame = len(audio) / n_total
+                    samples_per_frame = len(gen_audio) / n_total
             else:
                 ctx_start = max(0, n_total - n_new - context_frames)
                 window = all_flat[ctx_start:]
+                if ctx_start == 0 and decoder_prefix_codes is not None:
+                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
                 n_ctx = window.shape[0] - n_new
 
                 audio_list, sr = speech_tokenizer.decode({"audio_codes": window.unsqueeze(0)})

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -13,6 +13,7 @@ import soundfile as sf
 import torch
 
 from .continuation import (
+    DECODER_CONTEXT_FRAMES,
     continuation_state_decoder_context,
     normalize_return_continuation_state,
 )
@@ -100,13 +101,154 @@ class FasterQwen3TTS:
             "timing": timing,
             "rtf": rtf,
         }
-        if "continuation_state_delta" in timing:
-            info["continuation_state_delta"] = timing["continuation_state_delta"]
-        if "continuation_state" in timing:
-            info["continuation_state"] = timing["continuation_state"]
-        if "continuation_state_status" in timing:
-            info["continuation_state_status"] = timing["continuation_state_status"]
+        for key in (
+            "continuation_state_delta",
+            "continuation_state",
+            "continuation_state_status",
+        ):
+            if key in timing:
+                info[key] = timing[key]
         return info
+
+    @staticmethod
+    def _flatten_audio_array(audio: Any) -> np.ndarray:
+        if hasattr(audio, "cpu"):
+            return audio.flatten().cpu().numpy()
+        return audio.flatten() if hasattr(audio, "flatten") else audio
+
+    @staticmethod
+    def _resolve_decoder_prefix_codes(
+        continuation_state: Optional[Dict[str, Any]],
+        *,
+        device: torch.device | str,
+        ref_codes: Optional[torch.Tensor] = None,
+    ) -> Optional[torch.Tensor]:
+        decoder_prefix_codes = continuation_state_decoder_context(
+            continuation_state,
+            device=device,
+        )
+        if decoder_prefix_codes is None and ref_codes is not None:
+            decoder_prefix_codes = ref_codes.to(device)
+        return decoder_prefix_codes
+
+    def _decode_codec_ids_and_finalize(
+        self,
+        *,
+        speech_tokenizer: Any,
+        codec_ids: Optional[torch.Tensor],
+        continuation_state: Optional[Dict[str, Any]],
+        timing: dict,
+        continuation_return_mode: str,
+        ref_codes: Optional[torch.Tensor] = None,
+    ) -> Union[Tuple[list, int], Tuple[list, int, Dict[str, Any]]]:
+        if codec_ids is None:
+            logger.warning("Generation returned no tokens")
+            audio_arrays = [np.zeros(1, dtype=np.float32)]
+            if continuation_return_mode == "none":
+                return audio_arrays, self.sample_rate
+            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
+
+        decoder_prefix_codes = self._resolve_decoder_prefix_codes(
+            continuation_state,
+            device=codec_ids.device,
+            ref_codes=ref_codes,
+        )
+        codes_for_decode = (
+            torch.cat([decoder_prefix_codes, codec_ids], dim=0)
+            if decoder_prefix_codes is not None
+            else codec_ids
+        )
+        audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
+
+        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
+        total_len = codes_for_decode.shape[0]
+        audio_arrays = []
+        for audio in audio_list:
+            audio_array = self._flatten_audio_array(audio)
+            if ref_len > 0:
+                cut = int(ref_len / max(total_len, 1) * len(audio_array))
+                audio_array = audio_array[cut:]
+            audio_arrays.append(audio_array)
+
+        n_steps = timing["steps"]
+        audio_duration = n_steps / 12.0
+        total_time = timing["prefill_ms"] / 1000 + timing["decode_s"]
+        rtf = audio_duration / total_time if total_time > 0 else 0
+
+        logger.info(
+            f"Generated {audio_duration:.2f}s audio in {total_time:.2f}s "
+            f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
+        )
+
+        if continuation_return_mode == "none":
+            return audio_arrays, sr
+        return audio_arrays, sr, self._build_generation_info(timing, rtf)
+
+    def _iter_decoded_audio_chunks(
+        self,
+        *,
+        codec_stream: Generator[Tuple[torch.Tensor, dict], None, None],
+        speech_tokenizer: Any,
+        continuation_state: Optional[Dict[str, Any]],
+        decode_device: torch.device | str,
+        chunk_size: int,
+        ref_codes: Optional[torch.Tensor] = None,
+    ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        min_calibration_frames = max(DECODER_CONTEXT_FRAMES, chunk_size)
+        all_codes: list[torch.Tensor] = []
+        prev_audio_len = 0
+        samples_per_frame = None
+        decoder_prefix_codes = self._resolve_decoder_prefix_codes(
+            continuation_state,
+            device=decode_device,
+            ref_codes=ref_codes,
+        )
+
+        for codec_chunk, timing in codec_stream:
+            all_codes.append(codec_chunk)
+            n_new = codec_chunk.shape[0]
+            all_flat = torch.cat(all_codes, dim=0)
+            n_total = all_flat.shape[0]
+
+            if samples_per_frame is None:
+                codes_input = (
+                    torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
+                    if decoder_prefix_codes is not None
+                    else all_flat
+                )
+                audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_input.unsqueeze(0)})
+                audio = self._flatten_audio_array(audio_list[0])
+
+                if decoder_prefix_codes is not None:
+                    ref_audio_cut = int(
+                        decoder_prefix_codes.shape[0] / max(codes_input.shape[0], 1) * len(audio)
+                    )
+                    gen_audio = audio[ref_audio_cut:]
+                else:
+                    gen_audio = audio
+
+                new_audio = gen_audio[prev_audio_len:]
+                prev_audio_len = len(gen_audio)
+
+                if n_total >= min_calibration_frames:
+                    samples_per_frame = len(gen_audio) / n_total
+            else:
+                ctx_start = max(0, n_total - n_new - DECODER_CONTEXT_FRAMES)
+                window = all_flat[ctx_start:]
+                if ctx_start == 0 and decoder_prefix_codes is not None:
+                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
+                n_ctx = window.shape[0] - n_new
+
+                audio_list, sr = speech_tokenizer.decode({"audio_codes": window.unsqueeze(0)})
+                audio = self._flatten_audio_array(audio_list[0])
+
+                if n_ctx > 0:
+                    ctx_samples = int(round(n_ctx * samples_per_frame))
+                    new_audio = audio[ctx_samples:]
+                else:
+                    new_audio = audio
+
+            yield new_audio, sr, timing
         
     @classmethod
     def from_pretrained(
@@ -859,55 +1001,14 @@ class FasterQwen3TTS:
             continuation_state_device=continuation_state_device,
         )
 
-        if codec_ids is None:
-            logger.warning("Generation returned no tokens")
-            audio_arrays = [np.zeros(1, dtype=np.float32)]
-            if continuation_return_mode == "none":
-                return audio_arrays, self.sample_rate
-            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
-
-        # In ICL mode: prepend reference codes before decoding so the codec decoder
-        # has acoustic context from the reference audio (matches official implementation).
-        speech_tokenizer = m.speech_tokenizer
-        decoder_prefix_codes = continuation_state_decoder_context(
-            continuation_state,
-            device=codec_ids.device,
+        return self._decode_codec_ids_and_finalize(
+            speech_tokenizer=m.speech_tokenizer,
+            codec_ids=codec_ids,
+            continuation_state=continuation_state,
+            timing=timing,
+            continuation_return_mode=continuation_return_mode,
+            ref_codes=ref_codes,
         )
-        if decoder_prefix_codes is None and ref_codes is not None:
-            decoder_prefix_codes = ref_codes.to(codec_ids.device)
-        if decoder_prefix_codes is not None:
-            codes_for_decode = torch.cat([decoder_prefix_codes, codec_ids], dim=0)
-        else:
-            codes_for_decode = codec_ids
-        audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
-
-        # Convert to numpy and trim off the reference audio portion
-        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
-        total_len = codes_for_decode.shape[0]
-        audio_arrays = []
-        for a in audio_list:
-            if hasattr(a, 'cpu'):  # torch tensor
-                a = a.flatten().cpu().numpy()
-            else:  # already numpy
-                a = a.flatten() if hasattr(a, 'flatten') else a
-            if ref_len > 0:
-                cut = int(ref_len / max(total_len, 1) * len(a))
-                a = a[cut:]
-            audio_arrays.append(a)
-        
-        n_steps = timing['steps']
-        audio_duration = n_steps / 12.0  # 12 Hz codec
-        total_time = timing['prefill_ms']/1000 + timing['decode_s']
-        rtf = audio_duration / total_time if total_time > 0 else 0
-        
-        logger.info(
-            f"Generated {audio_duration:.2f}s audio in {total_time:.2f}s "
-            f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
-        )
-
-        if continuation_return_mode == "none":
-            return audio_arrays, sr
-        return audio_arrays, sr, self._build_generation_info(timing, rtf)
 
     @torch.inference_mode()
     def generate_voice_clone_streaming(
@@ -1003,12 +1104,6 @@ class FasterQwen3TTS:
         # 1. Accumulated decode for early chunks (correct, calibrates samples_per_frame)
         # 2. Sliding window with 25-frame left context once calibrated (constant cost)
         # This avoids boundary artifacts (pops) while keeping decode cost bounded.
-        context_frames = 25
-        min_calibration_frames = max(context_frames, chunk_size)
-        all_codes = []
-        prev_gen_audio_len = 0  # tracks position within the generated (non-ref) audio
-        samples_per_frame = None
-
         stream_fn = parity_generate_streaming if parity_mode else fast_generate_streaming
         stream_kwargs = dict(
             talker=talker,
@@ -1036,75 +1131,14 @@ class FasterQwen3TTS:
             stream_kwargs["talker_graph"] = self.talker_graph
         else:
             stream_kwargs["continuation_max_seq_len"] = self.max_seq_len
-
-        decoder_prefix_codes = continuation_state_decoder_context(
-            continuation_state,
-            device=tie.device,
+        yield from self._iter_decoded_audio_chunks(
+            codec_stream=stream_fn(**stream_kwargs),
+            speech_tokenizer=speech_tokenizer,
+            continuation_state=continuation_state,
+            decode_device=tie.device,
+            chunk_size=chunk_size,
+            ref_codes=ref_codes,
         )
-        if decoder_prefix_codes is None and ref_codes is not None:
-            decoder_prefix_codes = ref_codes.to(tie.device)
-
-        for codec_chunk, timing in stream_fn(**stream_kwargs):
-            all_codes.append(codec_chunk)
-            n_new = codec_chunk.shape[0]
-            all_flat = torch.cat(all_codes, dim=0)
-            n_total = all_flat.shape[0]
-
-            if samples_per_frame is None:
-                # Phase 1: accumulated decode until we can calibrate.
-                # In ICL mode prepend reference codes so the codec decoder has acoustic
-                # context from the reference audio (matches official implementation).
-                if decoder_prefix_codes is not None:
-                    codes_input = torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
-                else:
-                    codes_input = all_flat
-                audio_list, sr = speech_tokenizer.decode(
-                    {"audio_codes": codes_input.unsqueeze(0)}
-                )
-                audio = audio_list[0]
-                if hasattr(audio, 'cpu'):
-                    audio = audio.flatten().cpu().numpy()
-                else:
-                    audio = audio.flatten() if hasattr(audio, 'flatten') else audio
-
-                # Separate out reference audio portion; track position in generated audio only
-                if decoder_prefix_codes is not None:
-                    ref_len = decoder_prefix_codes.shape[0]
-                    total_len = codes_input.shape[0]
-                    ref_audio_cut = int(ref_len / max(total_len, 1) * len(audio))
-                    gen_audio = audio[ref_audio_cut:]
-                else:
-                    gen_audio = audio
-
-                new_audio = gen_audio[prev_gen_audio_len:]
-                prev_gen_audio_len = len(gen_audio)
-
-                if n_total >= min_calibration_frames:
-                    samples_per_frame = len(gen_audio) / n_total
-            else:
-                # Phase 2: sliding window with left context
-                ctx_start = max(0, n_total - n_new - context_frames)
-                window = all_flat[ctx_start:]
-                if ctx_start == 0 and decoder_prefix_codes is not None:
-                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
-                n_ctx = window.shape[0] - n_new
-
-                audio_list, sr = speech_tokenizer.decode(
-                    {"audio_codes": window.unsqueeze(0)}
-                )
-                audio = audio_list[0]
-                if hasattr(audio, 'cpu'):
-                    audio = audio.flatten().cpu().numpy()
-                else:
-                    audio = audio.flatten() if hasattr(audio, 'flatten') else audio
-
-                if n_ctx > 0:
-                    ctx_samples = int(round(n_ctx * samples_per_frame))
-                    new_audio = audio[ctx_samples:]
-                else:
-                    new_audio = audio
-
-            yield new_audio, sr, timing
 
     @torch.inference_mode()
     def generate_custom_voice(
@@ -1173,50 +1207,13 @@ class FasterQwen3TTS:
             continuation_state_device=continuation_state_device,
         )
 
-        if codec_ids is None:
-            logger.warning("Generation returned no tokens")
-            audio_arrays = [np.zeros(1, dtype=np.float32)]
-            if continuation_return_mode == "none":
-                return audio_arrays, self.sample_rate
-            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
-
-        speech_tokenizer = m.speech_tokenizer
-        decoder_prefix_codes = continuation_state_decoder_context(
-            continuation_state,
-            device=codec_ids.device,
+        return self._decode_codec_ids_and_finalize(
+            speech_tokenizer=m.speech_tokenizer,
+            codec_ids=codec_ids,
+            continuation_state=continuation_state,
+            timing=timing,
+            continuation_return_mode=continuation_return_mode,
         )
-        if decoder_prefix_codes is not None:
-            codes_for_decode = torch.cat([decoder_prefix_codes, codec_ids], dim=0)
-        else:
-            codes_for_decode = codec_ids
-        audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
-
-        audio_arrays = []
-        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
-        total_len = codes_for_decode.shape[0]
-        for a in audio_list:
-            if hasattr(a, "cpu"):
-                a = a.flatten().cpu().numpy()
-            else:
-                a = a.flatten() if hasattr(a, "flatten") else a
-            if ref_len > 0:
-                cut = int(ref_len / max(total_len, 1) * len(a))
-                a = a[cut:]
-            audio_arrays.append(a)
-
-        n_steps = timing["steps"]
-        audio_duration = n_steps / 12.0
-        total_time = timing["prefill_ms"] / 1000 + timing["decode_s"]
-        rtf = audio_duration / total_time if total_time > 0 else 0
-
-        logger.info(
-            f"Generated {audio_duration:.2f}s audio in {total_time:.2f}s "
-            f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
-        )
-
-        if continuation_return_mode == "none":
-            return audio_arrays, sr
-        return audio_arrays, sr, self._build_generation_info(timing, rtf)
 
     @torch.inference_mode()
     def generate_custom_voice_streaming(
@@ -1262,91 +1259,35 @@ class FasterQwen3TTS:
             non_streaming_mode=non_streaming_mode,
         )
 
-        speech_tokenizer = m.speech_tokenizer
-
-        context_frames = 25
-        min_calibration_frames = max(context_frames, chunk_size)
-        all_codes = []
-        prev_audio_len = 0
-        samples_per_frame = None
-        decoder_prefix_codes = continuation_state_decoder_context(
-            continuation_state,
-            device=tie.device,
-        )
-
-        for codec_chunk, timing in fast_generate_streaming(
-            talker=talker,
-            talker_input_embeds=tie,
-            attention_mask=tam,
-            trailing_text_hiddens=tth,
-            tts_pad_embed=tpe,
-            config=config,
-            predictor_graph=self.predictor_graph,
-            talker_graph=self.talker_graph,
-            max_new_tokens=max_new_tokens,
-            min_new_tokens=min_new_tokens,
-            temperature=temperature,
-            top_k=top_k,
-            top_p=top_p,
-            do_sample=do_sample,
-            repetition_penalty=repetition_penalty,
-            chunk_size=chunk_size,
+        yield from self._iter_decoded_audio_chunks(
+            codec_stream=fast_generate_streaming(
+                talker=talker,
+                talker_input_embeds=tie,
+                attention_mask=tam,
+                trailing_text_hiddens=tth,
+                tts_pad_embed=tpe,
+                config=config,
+                predictor_graph=self.predictor_graph,
+                talker_graph=self.talker_graph,
+                max_new_tokens=max_new_tokens,
+                min_new_tokens=min_new_tokens,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                do_sample=do_sample,
+                repetition_penalty=repetition_penalty,
+                chunk_size=chunk_size,
+                continuation_state=continuation_state,
+                return_continuation_state=return_continuation_state,
+                continuation_mode="custom_voice",
+                continuation_non_streaming_mode=non_streaming_mode,
+                continuation_state_device=continuation_state_device,
+            ),
+            speech_tokenizer=m.speech_tokenizer,
             continuation_state=continuation_state,
-            return_continuation_state=return_continuation_state,
-            continuation_mode="custom_voice",
-            continuation_non_streaming_mode=non_streaming_mode,
-            continuation_state_device=continuation_state_device,
-        ):
-            all_codes.append(codec_chunk)
-            n_new = codec_chunk.shape[0]
-            all_flat = torch.cat(all_codes, dim=0)
-            n_total = all_flat.shape[0]
-
-            if samples_per_frame is None:
-                codes_input = (
-                    torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
-                    if decoder_prefix_codes is not None
-                    else all_flat
-                )
-                audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_input.unsqueeze(0)})
-                audio = audio_list[0]
-                if hasattr(audio, "cpu"):
-                    audio = audio.flatten().cpu().numpy()
-                else:
-                    audio = audio.flatten() if hasattr(audio, "flatten") else audio
-
-                if decoder_prefix_codes is not None:
-                    ref_len = decoder_prefix_codes.shape[0]
-                    ref_audio_cut = int(ref_len / max(codes_input.shape[0], 1) * len(audio))
-                    gen_audio = audio[ref_audio_cut:]
-                else:
-                    gen_audio = audio
-                new_audio = gen_audio[prev_audio_len:]
-                prev_audio_len = len(gen_audio)
-
-                if n_total >= min_calibration_frames:
-                    samples_per_frame = len(gen_audio) / n_total
-            else:
-                ctx_start = max(0, n_total - n_new - context_frames)
-                window = all_flat[ctx_start:]
-                if ctx_start == 0 and decoder_prefix_codes is not None:
-                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
-                n_ctx = window.shape[0] - n_new
-
-                audio_list, sr = speech_tokenizer.decode({"audio_codes": window.unsqueeze(0)})
-                audio = audio_list[0]
-                if hasattr(audio, "cpu"):
-                    audio = audio.flatten().cpu().numpy()
-                else:
-                    audio = audio.flatten() if hasattr(audio, "flatten") else audio
-
-                if n_ctx > 0:
-                    ctx_samples = int(round(n_ctx * samples_per_frame))
-                    new_audio = audio[ctx_samples:]
-                else:
-                    new_audio = audio
-
-            yield new_audio, sr, timing
+            decode_device=tie.device,
+            chunk_size=chunk_size,
+        )
 
     @torch.inference_mode()
     def generate_voice_design(
@@ -1410,50 +1351,13 @@ class FasterQwen3TTS:
             continuation_state_device=continuation_state_device,
         )
 
-        if codec_ids is None:
-            logger.warning("Generation returned no tokens")
-            audio_arrays = [np.zeros(1, dtype=np.float32)]
-            if continuation_return_mode == "none":
-                return audio_arrays, self.sample_rate
-            return audio_arrays, self.sample_rate, self._build_generation_info(timing, 0.0)
-
-        speech_tokenizer = m.speech_tokenizer
-        decoder_prefix_codes = continuation_state_decoder_context(
-            continuation_state,
-            device=codec_ids.device,
+        return self._decode_codec_ids_and_finalize(
+            speech_tokenizer=m.speech_tokenizer,
+            codec_ids=codec_ids,
+            continuation_state=continuation_state,
+            timing=timing,
+            continuation_return_mode=continuation_return_mode,
         )
-        if decoder_prefix_codes is not None:
-            codes_for_decode = torch.cat([decoder_prefix_codes, codec_ids], dim=0)
-        else:
-            codes_for_decode = codec_ids
-        audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_for_decode.unsqueeze(0)})
-
-        audio_arrays = []
-        ref_len = decoder_prefix_codes.shape[0] if decoder_prefix_codes is not None else 0
-        total_len = codes_for_decode.shape[0]
-        for a in audio_list:
-            if hasattr(a, "cpu"):
-                a = a.flatten().cpu().numpy()
-            else:
-                a = a.flatten() if hasattr(a, "flatten") else a
-            if ref_len > 0:
-                cut = int(ref_len / max(total_len, 1) * len(a))
-                a = a[cut:]
-            audio_arrays.append(a)
-
-        n_steps = timing["steps"]
-        audio_duration = n_steps / 12.0
-        total_time = timing["prefill_ms"] / 1000 + timing["decode_s"]
-        rtf = audio_duration / total_time if total_time > 0 else 0
-
-        logger.info(
-            f"Generated {audio_duration:.2f}s audio in {total_time:.2f}s "
-            f"({timing['ms_per_step']:.1f}ms/step, RTF: {rtf:.2f})"
-        )
-
-        if continuation_return_mode == "none":
-            return audio_arrays, sr
-        return audio_arrays, sr, self._build_generation_info(timing, rtf)
 
     @torch.inference_mode()
     def generate_voice_design_streaming(
@@ -1494,88 +1398,32 @@ class FasterQwen3TTS:
             non_streaming_mode=non_streaming_mode,
         )
 
-        speech_tokenizer = m.speech_tokenizer
-
-        context_frames = 25
-        min_calibration_frames = max(context_frames, chunk_size)
-        all_codes = []
-        prev_audio_len = 0
-        samples_per_frame = None
-        decoder_prefix_codes = continuation_state_decoder_context(
-            continuation_state,
-            device=tie.device,
-        )
-
-        for codec_chunk, timing in fast_generate_streaming(
-            talker=talker,
-            talker_input_embeds=tie,
-            attention_mask=tam,
-            trailing_text_hiddens=tth,
-            tts_pad_embed=tpe,
-            config=config,
-            predictor_graph=self.predictor_graph,
-            talker_graph=self.talker_graph,
-            max_new_tokens=max_new_tokens,
-            min_new_tokens=min_new_tokens,
-            temperature=temperature,
-            top_k=top_k,
-            top_p=top_p,
-            do_sample=do_sample,
-            repetition_penalty=repetition_penalty,
-            chunk_size=chunk_size,
+        yield from self._iter_decoded_audio_chunks(
+            codec_stream=fast_generate_streaming(
+                talker=talker,
+                talker_input_embeds=tie,
+                attention_mask=tam,
+                trailing_text_hiddens=tth,
+                tts_pad_embed=tpe,
+                config=config,
+                predictor_graph=self.predictor_graph,
+                talker_graph=self.talker_graph,
+                max_new_tokens=max_new_tokens,
+                min_new_tokens=min_new_tokens,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                do_sample=do_sample,
+                repetition_penalty=repetition_penalty,
+                chunk_size=chunk_size,
+                continuation_state=continuation_state,
+                return_continuation_state=return_continuation_state,
+                continuation_mode="voice_design",
+                continuation_non_streaming_mode=non_streaming_mode,
+                continuation_state_device=continuation_state_device,
+            ),
+            speech_tokenizer=m.speech_tokenizer,
             continuation_state=continuation_state,
-            return_continuation_state=return_continuation_state,
-            continuation_mode="voice_design",
-            continuation_non_streaming_mode=non_streaming_mode,
-            continuation_state_device=continuation_state_device,
-        ):
-            all_codes.append(codec_chunk)
-            n_new = codec_chunk.shape[0]
-            all_flat = torch.cat(all_codes, dim=0)
-            n_total = all_flat.shape[0]
-
-            if samples_per_frame is None:
-                codes_input = (
-                    torch.cat([decoder_prefix_codes.to(all_flat.device), all_flat], dim=0)
-                    if decoder_prefix_codes is not None
-                    else all_flat
-                )
-                audio_list, sr = speech_tokenizer.decode({"audio_codes": codes_input.unsqueeze(0)})
-                audio = audio_list[0]
-                if hasattr(audio, "cpu"):
-                    audio = audio.flatten().cpu().numpy()
-                else:
-                    audio = audio.flatten() if hasattr(audio, "flatten") else audio
-
-                if decoder_prefix_codes is not None:
-                    ref_len = decoder_prefix_codes.shape[0]
-                    ref_audio_cut = int(ref_len / max(codes_input.shape[0], 1) * len(audio))
-                    gen_audio = audio[ref_audio_cut:]
-                else:
-                    gen_audio = audio
-                new_audio = gen_audio[prev_audio_len:]
-                prev_audio_len = len(gen_audio)
-
-                if n_total >= min_calibration_frames:
-                    samples_per_frame = len(gen_audio) / n_total
-            else:
-                ctx_start = max(0, n_total - n_new - context_frames)
-                window = all_flat[ctx_start:]
-                if ctx_start == 0 and decoder_prefix_codes is not None:
-                    window = torch.cat([decoder_prefix_codes.to(window.device), window], dim=0)
-                n_ctx = window.shape[0] - n_new
-
-                audio_list, sr = speech_tokenizer.decode({"audio_codes": window.unsqueeze(0)})
-                audio = audio_list[0]
-                if hasattr(audio, "cpu"):
-                    audio = audio.flatten().cpu().numpy()
-                else:
-                    audio = audio.flatten() if hasattr(audio, "flatten") else audio
-
-                if n_ctx > 0:
-                    ctx_samples = int(round(n_ctx * samples_per_frame))
-                    new_audio = audio[ctx_samples:]
-                else:
-                    new_audio = audio
-
-            yield new_audio, sr, timing
+            decode_device=tie.device,
+            chunk_size=chunk_size,
+        )

--- a/faster_qwen3_tts/sampling.py
+++ b/faster_qwen3_tts/sampling.py
@@ -7,6 +7,20 @@ import torch
 import torch.nn.functional as F
 
 
+def build_suppress_mask(
+    vocab_size: int,
+    eos_id: int,
+    *,
+    device: torch.device | str,
+) -> torch.Tensor:
+    """Build the standard Qwen TTS suppress mask for reserved high token ids."""
+    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
+    suppress_start = max(0, vocab_size - 1024)
+    suppress_mask[suppress_start:] = True
+    suppress_mask[eos_id] = False
+    return suppress_mask
+
+
 def apply_repetition_penalty(
     logits: torch.Tensor,
     token_history: torch.Tensor,

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -10,6 +10,16 @@ from typing import Generator, Tuple
 
 import torch
 
+from .continuation import (
+    apply_continuation_state_delta,
+    build_continuation_state_status,
+    build_continuation_state_delta,
+    continuation_state_first_token_history,
+    continuation_state_to_dynamic_cache,
+    model_signature,
+    normalize_return_continuation_state,
+    validate_full_continuation_state,
+)
 from .predictor_graph import PredictorGraph
 from .sampling import apply_repetition_penalty, sample_logits
 from .talker_graph import TalkerGraph
@@ -33,6 +43,12 @@ def fast_generate_streaming(
     do_sample: bool = True,
     repetition_penalty: float = 1.05,
     chunk_size: int = 12,
+    continuation_state: dict | None = None,
+    return_continuation_state: bool | str = False,
+    continuation_mode: str = "voice_clone",
+    continuation_non_streaming_mode: bool = False,
+    continuation_state_device: str = "cpu",
+    continuation_max_seq_len: int | None = None,
 ) -> Generator[Tuple[torch.Tensor, dict], None, None]:
     """
     Streaming autoregressive generation with CUDA-graphed predictor and talker.
@@ -51,6 +67,27 @@ def fast_generate_streaming(
         if i != eos_id:
             suppress_mask[i] = True
 
+    continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
+    signature = model_signature(
+        num_layers=talker_graph.num_layers,
+        max_seq_len=talker_graph.max_seq_len,
+        hidden_size=talker_graph.hidden_size,
+    )
+    validate_full_continuation_state(
+        continuation_state,
+        mode=continuation_mode,
+        expected_signature=signature,
+    )
+    if (
+        continuation_state is not None
+        and continuation_state["non_streaming_mode"] != bool(continuation_non_streaming_mode)
+    ):
+        raise ValueError(
+            "continuation_state non_streaming_mode does not match the current request"
+        )
+    base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
+    running_state = continuation_state
+
     predictor = talker.code_predictor
     talker_codec_embed = talker.get_input_embeddings()
     talker_codec_head = talker.codec_head
@@ -59,19 +96,67 @@ def fast_generate_streaming(
 
     # === PREFILL (still uses HF forward for variable-length prefill) ===
     t_start = time.time()
-
-    out = talker.forward(
-        inputs_embeds=talker_input_embeds,
-        attention_mask=attention_mask,
-        use_cache=True,
-        output_hidden_states=True,
-        return_dict=True,
-        trailing_text_hidden=trailing_text_hiddens,
-        tts_pad_embed=tts_pad_embed,
-        generation_step=None,
-        past_hidden=None,
-        past_key_values=None,
-    )
+    full_attention_mask = attention_mask
+    if continuation_state is None:
+        out = talker.forward(
+            inputs_embeds=talker_input_embeds,
+            attention_mask=attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=None,
+        )
+    else:
+        prefix_len = int(talker_input_embeds.shape[1])
+        required_len = base_seq_len + prefix_len
+        if required_len >= talker_graph.max_seq_len - 1:
+            raise RuntimeError(
+                "Continuation prefill exceeds max_seq_len. Reset the continuation state "
+                "or increase max_seq_len."
+            )
+        full_attention_mask = torch.ones(
+            attention_mask.shape[0],
+            required_len,
+            dtype=attention_mask.dtype,
+            device=attention_mask.device,
+        )
+        prefix_cache_position = torch.arange(
+            base_seq_len,
+            required_len,
+            device=device,
+        )
+        prefix_input_ids = torch.zeros(
+            (talker_input_embeds.shape[0], prefix_len),
+            dtype=torch.long,
+            device=device,
+        )
+        talker.rope_deltas = continuation_state["rope_deltas"].to(
+            device=talker_input_embeds.device,
+            dtype=torch.float32,
+        )
+        dynamic_cache = continuation_state_to_dynamic_cache(
+            continuation_state,
+            config=talker.config,
+            device=device,
+        )
+        out = talker.forward(
+            input_ids=prefix_input_ids,
+            inputs_embeds=talker_input_embeds,
+            attention_mask=full_attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=dynamic_cache,
+            cache_position=prefix_cache_position,
+        )
 
     talker_past_kv = out.past_key_values
     past_hidden = out.past_hidden
@@ -91,17 +176,22 @@ def fast_generate_streaming(
 
     prefill_len = talker_graph.prefill_kv(talker_past_kv)
     rope_deltas = getattr(talker, "rope_deltas", None)
-    talker_graph.set_generation_state(attention_mask, rope_deltas)
+    talker_graph.set_generation_state(full_attention_mask, rope_deltas)
 
     torch.cuda.synchronize()
     t_prefill = time.time() - t_start
 
     # === DECODE LOOP — yield chunks ===
     chunk_buffer = []
-    all_first_tokens = []  # for repetition penalty across chunks
+    pending_first_tokens = []
+    all_first_tokens = continuation_state_first_token_history(
+        continuation_state,
+        device=device,
+    )
     total_steps = 0
     chunk_count = 0
     chunk_start = time.time()
+    last_export_seq_len = base_seq_len
 
     for step_idx in range(max_new_tokens):
         if token.item() == eos_id:
@@ -115,6 +205,7 @@ def fast_generate_streaming(
         all_cb = torch.cat([token.view(1), codebook_token_ids])
         chunk_buffer.append(all_cb.detach())
         all_first_tokens.append(token.detach())
+        pending_first_tokens.append(token.detach())
 
         # --- Build input embedding for talker ---
         codec_hiddens = [last_id_hidden]
@@ -158,8 +249,7 @@ def fast_generate_streaming(
             torch.cuda.synchronize()
             chunk_decode_time = time.time() - chunk_start
             total_steps += len(chunk_buffer)
-
-            yield torch.stack(chunk_buffer), {
+            timing = {
                 'chunk_index': chunk_count,
                 'chunk_steps': len(chunk_buffer),
                 'prefill_ms': t_prefill * 1000 if chunk_count == 0 else 0,
@@ -167,8 +257,35 @@ def fast_generate_streaming(
                 'total_steps_so_far': total_steps,
                 'is_final': False,
             }
+            if continuation_return_mode != "none":
+                seq_len = prefill_len + total_steps
+                delta = build_continuation_state_delta(
+                    static_cache=talker_graph.static_cache,
+                    base_seq_len=last_export_seq_len,
+                    seq_len=seq_len,
+                    rope_deltas=talker_graph.rope_deltas,
+                    first_codebook_history_delta=pending_first_tokens,
+                    codec_ids_delta=chunk_buffer,
+                    mode=continuation_mode,
+                    non_streaming_mode=continuation_non_streaming_mode,
+                    model_signature_dict=signature,
+                    device=continuation_state_device,
+                )
+                if continuation_return_mode == "delta":
+                    timing["continuation_state_delta"] = delta
+                else:
+                    running_state = apply_continuation_state_delta(running_state, delta)
+                    timing["continuation_state"] = running_state
+                timing["continuation_state_status"] = build_continuation_state_status(
+                    seq_len=seq_len,
+                    max_seq_len=talker_graph.max_seq_len,
+                )
+                last_export_seq_len = seq_len
+
+            yield torch.stack(chunk_buffer), timing
 
             chunk_buffer = []
+            pending_first_tokens = []
             chunk_count += 1
             chunk_start = time.time()
 
@@ -177,8 +294,7 @@ def fast_generate_streaming(
         torch.cuda.synchronize()
         chunk_decode_time = time.time() - chunk_start
         total_steps += len(chunk_buffer)
-
-        yield torch.stack(chunk_buffer), {
+        timing = {
             'chunk_index': chunk_count,
             'chunk_steps': len(chunk_buffer),
             'prefill_ms': t_prefill * 1000 if chunk_count == 0 else 0,
@@ -186,6 +302,31 @@ def fast_generate_streaming(
             'total_steps_so_far': total_steps,
             'is_final': True,
         }
+        if continuation_return_mode != "none":
+            seq_len = prefill_len + total_steps
+            delta = build_continuation_state_delta(
+                static_cache=talker_graph.static_cache,
+                base_seq_len=last_export_seq_len,
+                seq_len=seq_len,
+                rope_deltas=talker_graph.rope_deltas,
+                first_codebook_history_delta=pending_first_tokens,
+                codec_ids_delta=chunk_buffer,
+                mode=continuation_mode,
+                non_streaming_mode=continuation_non_streaming_mode,
+                model_signature_dict=signature,
+                device=continuation_state_device,
+            )
+            if continuation_return_mode == "delta":
+                timing["continuation_state_delta"] = delta
+            else:
+                running_state = apply_continuation_state_delta(running_state, delta)
+                timing["continuation_state"] = running_state
+            timing["continuation_state_status"] = build_continuation_state_status(
+                seq_len=seq_len,
+                max_seq_len=talker_graph.max_seq_len,
+            )
+
+        yield torch.stack(chunk_buffer), timing
 
 
 @torch.inference_mode()
@@ -204,6 +345,11 @@ def parity_generate_streaming(
     do_sample: bool = True,
     repetition_penalty: float = 1.05,
     chunk_size: int = 12,
+    continuation_state: dict | None = None,
+    return_continuation_state: bool | str = False,
+    continuation_mode: str = "voice_clone",
+    continuation_non_streaming_mode: bool = False,
+    continuation_state_device: str = "cpu",
 ) -> Generator[Tuple[torch.Tensor, dict], None, None]:
     """
     Streaming generation without CUDA graphs (dynamic cache).
@@ -224,21 +370,96 @@ def parity_generate_streaming(
         if i != eos_id:
             suppress_mask[i] = True
 
+    continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
+    if continuation_max_seq_len is None:
+        continuation_max_seq_len = (
+            continuation_state["model_signature"]["max_seq_len"]
+            if continuation_state is not None
+            else int(talker_input_embeds.shape[1] + max_new_tokens + 1)
+        )
+    signature = model_signature(
+        num_layers=talker.config.num_hidden_layers,
+        max_seq_len=continuation_max_seq_len,
+        hidden_size=talker.config.hidden_size,
+    )
+    validate_full_continuation_state(
+        continuation_state,
+        mode=continuation_mode,
+        expected_signature=signature,
+    )
+    if (
+        continuation_state is not None
+        and continuation_state["non_streaming_mode"] != bool(continuation_non_streaming_mode)
+    ):
+        raise ValueError(
+            "continuation_state non_streaming_mode does not match the current request"
+        )
+    base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
+    running_state = continuation_state
+
     # === PREFILL ===
     t_start = time.time()
-
-    out = talker.forward(
-        inputs_embeds=talker_input_embeds,
-        attention_mask=attention_mask,
-        use_cache=True,
-        output_hidden_states=True,
-        return_dict=True,
-        trailing_text_hidden=trailing_text_hiddens,
-        tts_pad_embed=tts_pad_embed,
-        generation_step=None,
-        past_hidden=None,
-        past_key_values=None,
-    )
+    full_attention_mask = attention_mask
+    if continuation_state is None:
+        out = talker.forward(
+            inputs_embeds=talker_input_embeds,
+            attention_mask=attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=None,
+        )
+    else:
+        prefix_len = int(talker_input_embeds.shape[1])
+        required_len = base_seq_len + prefix_len
+        if required_len >= continuation_max_seq_len - 1:
+            raise RuntimeError(
+                "Continuation prefill exceeds max_seq_len. Reset the continuation state "
+                "or increase max_seq_len."
+            )
+        full_attention_mask = torch.ones(
+            attention_mask.shape[0],
+            required_len,
+            dtype=attention_mask.dtype,
+            device=attention_mask.device,
+        )
+        prefix_cache_position = torch.arange(
+            base_seq_len,
+            required_len,
+            device=device,
+        )
+        prefix_input_ids = torch.zeros(
+            (talker_input_embeds.shape[0], prefix_len),
+            dtype=torch.long,
+            device=device,
+        )
+        talker.rope_deltas = continuation_state["rope_deltas"].to(
+            device=talker_input_embeds.device,
+            dtype=torch.float32,
+        )
+        talker_past_kv = continuation_state_to_dynamic_cache(
+            continuation_state,
+            config=talker.config,
+            device=device,
+        )
+        out = talker.forward(
+            input_ids=prefix_input_ids,
+            inputs_embeds=talker_input_embeds,
+            attention_mask=full_attention_mask,
+            use_cache=True,
+            output_hidden_states=True,
+            return_dict=True,
+            trailing_text_hidden=trailing_text_hiddens,
+            tts_pad_embed=tts_pad_embed,
+            generation_step=None,
+            past_hidden=None,
+            past_key_values=talker_past_kv,
+            cache_position=prefix_cache_position,
+        )
 
     talker_past_kv = out.past_key_values
     past_hidden = out.past_hidden
@@ -256,18 +477,22 @@ def parity_generate_streaming(
         suppress_tokens=[eos_id] if suppress_eos else None,
     )
 
-    if attention_mask is not None:
-        attention_mask = attention_mask.clone()
+    attention_mask = full_attention_mask.clone() if full_attention_mask is not None else None
 
     torch.cuda.synchronize()
     t_prefill = time.time() - t_start
 
     # === DECODE LOOP — yield chunks ===
     chunk_buffer = []
-    all_first_tokens = []
+    pending_first_tokens = []
+    all_first_tokens = continuation_state_first_token_history(
+        continuation_state,
+        device=device,
+    )
     total_steps = 0
     chunk_count = 0
     chunk_start = time.time()
+    last_export_seq_len = base_seq_len
 
     for _ in range(max_new_tokens):
         if token.item() == eos_id:
@@ -305,6 +530,7 @@ def parity_generate_streaming(
 
         chunk_buffer.append(codec_ids.squeeze(0).detach())
         all_first_tokens.append(token.detach())
+        pending_first_tokens.append(token.detach())
 
         logits = out.logits[:, -1, :]
         if repetition_penalty != 1.0 and all_first_tokens:
@@ -330,8 +556,7 @@ def parity_generate_streaming(
             torch.cuda.synchronize()
             chunk_decode_time = time.time() - chunk_start
             total_steps += len(chunk_buffer)
-
-            yield torch.stack(chunk_buffer), {
+            timing = {
                 'chunk_index': chunk_count,
                 'chunk_steps': len(chunk_buffer),
                 'prefill_ms': t_prefill * 1000 if chunk_count == 0 else 0,
@@ -339,8 +564,35 @@ def parity_generate_streaming(
                 'total_steps_so_far': total_steps,
                 'is_final': False,
             }
+            if continuation_return_mode != "none":
+                seq_len = int(attention_mask.shape[1]) if attention_mask is not None else base_seq_len + total_steps
+                delta = build_continuation_state_delta(
+                    static_cache=talker_past_kv,
+                    base_seq_len=last_export_seq_len,
+                    seq_len=seq_len,
+                    rope_deltas=talker.rope_deltas,
+                    first_codebook_history_delta=pending_first_tokens,
+                    codec_ids_delta=chunk_buffer,
+                    mode=continuation_mode,
+                    non_streaming_mode=continuation_non_streaming_mode,
+                    model_signature_dict=signature,
+                    device=continuation_state_device,
+                )
+                if continuation_return_mode == "delta":
+                    timing["continuation_state_delta"] = delta
+                else:
+                    running_state = apply_continuation_state_delta(running_state, delta)
+                    timing["continuation_state"] = running_state
+                timing["continuation_state_status"] = build_continuation_state_status(
+                    seq_len=seq_len,
+                    max_seq_len=continuation_max_seq_len,
+                )
+                last_export_seq_len = seq_len
+
+            yield torch.stack(chunk_buffer), timing
 
             chunk_buffer = []
+            pending_first_tokens = []
             chunk_count += 1
             chunk_start = time.time()
 
@@ -348,8 +600,7 @@ def parity_generate_streaming(
         torch.cuda.synchronize()
         chunk_decode_time = time.time() - chunk_start
         total_steps += len(chunk_buffer)
-
-        yield torch.stack(chunk_buffer), {
+        timing = {
             'chunk_index': chunk_count,
             'chunk_steps': len(chunk_buffer),
             'prefill_ms': t_prefill * 1000 if chunk_count == 0 else 0,
@@ -357,3 +608,28 @@ def parity_generate_streaming(
             'total_steps_so_far': total_steps,
             'is_final': True,
         }
+        if continuation_return_mode != "none":
+            seq_len = int(attention_mask.shape[1]) if attention_mask is not None else base_seq_len + total_steps
+            delta = build_continuation_state_delta(
+                static_cache=talker_past_kv,
+                base_seq_len=last_export_seq_len,
+                seq_len=seq_len,
+                rope_deltas=talker.rope_deltas,
+                first_codebook_history_delta=pending_first_tokens,
+                codec_ids_delta=chunk_buffer,
+                mode=continuation_mode,
+                non_streaming_mode=continuation_non_streaming_mode,
+                model_signature_dict=signature,
+                device=continuation_state_device,
+            )
+            if continuation_return_mode == "delta":
+                timing["continuation_state_delta"] = delta
+            else:
+                running_state = apply_continuation_state_delta(running_state, delta)
+                timing["continuation_state"] = running_state
+            timing["continuation_state_status"] = build_continuation_state_status(
+                seq_len=seq_len,
+                max_seq_len=continuation_max_seq_len,
+            )
+
+        yield torch.stack(chunk_buffer), timing

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -62,23 +62,26 @@ def fast_generate_streaming(
     suppress_mask = build_suppress_mask(vocab_size, eos_id, device=device)
 
     continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
-    signature = model_signature(
-        num_layers=talker_graph.num_layers,
-        max_seq_len=talker_graph.max_seq_len,
-        hidden_size=talker_graph.hidden_size,
-    )
-    validate_full_continuation_state(
-        continuation_state,
-        mode=continuation_mode,
-        expected_signature=signature,
-    )
-    if (
-        continuation_state is not None
-        and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
-    ):
-        raise ValueError(
-            "continuation_state non_streaming_mode does not match the current request"
+    continuation_active = continuation_state is not None or continuation_return_mode != "none"
+    signature = None
+    if continuation_active:
+        signature = model_signature(
+            num_layers=talker_graph.num_layers,
+            max_seq_len=talker_graph.max_seq_len,
+            hidden_size=talker_graph.hidden_size,
         )
+        validate_full_continuation_state(
+            continuation_state,
+            mode=continuation_mode,
+            expected_signature=signature,
+        )
+        if (
+            continuation_state is not None
+            and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
+        ):
+            raise ValueError(
+                "continuation_state non_streaming_mode does not match the current request"
+            )
     base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
     running_state = continuation_state
 
@@ -301,29 +304,32 @@ def parity_generate_streaming(
     suppress_mask = build_suppress_mask(vocab_size, eos_id, device=device)
 
     continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
-    if continuation_max_seq_len is None:
-        continuation_max_seq_len = (
-            continuation_state["model_signature"]["max_seq_len"]
-            if continuation_state is not None
-            else int(talker_input_embeds.shape[1] + max_new_tokens + 1)
+    continuation_active = continuation_state is not None or continuation_return_mode != "none"
+    signature = None
+    if continuation_active:
+        if continuation_max_seq_len is None:
+            continuation_max_seq_len = (
+                continuation_state["model_signature"]["max_seq_len"]
+                if continuation_state is not None
+                else int(talker_input_embeds.shape[1] + max_new_tokens + 1)
+            )
+        signature = model_signature(
+            num_layers=talker.config.num_hidden_layers,
+            max_seq_len=continuation_max_seq_len,
+            hidden_size=talker.config.hidden_size,
         )
-    signature = model_signature(
-        num_layers=talker.config.num_hidden_layers,
-        max_seq_len=continuation_max_seq_len,
-        hidden_size=talker.config.hidden_size,
-    )
-    validate_full_continuation_state(
-        continuation_state,
-        mode=continuation_mode,
-        expected_signature=signature,
-    )
-    if (
-        continuation_state is not None
-        and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
-    ):
-        raise ValueError(
-            "continuation_state non_streaming_mode does not match the current request"
+        validate_full_continuation_state(
+            continuation_state,
+            mode=continuation_mode,
+            expected_signature=signature,
         )
+        if (
+            continuation_state is not None
+            and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
+        ):
+            raise ValueError(
+                "continuation_state non_streaming_mode does not match the current request"
+            )
     base_seq_len = 0 if continuation_state is None else int(continuation_state["seq_len"])
     running_state = continuation_state
 

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -11,17 +11,15 @@ from typing import Generator, Tuple
 import torch
 
 from .continuation import (
-    apply_continuation_state_delta,
-    build_continuation_state_status,
-    build_continuation_state_delta,
+    attach_continuation_result,
     continuation_state_first_token_history,
-    continuation_state_to_dynamic_cache,
     model_signature,
     normalize_return_continuation_state,
+    prefill_with_continuation,
     validate_full_continuation_state,
 )
 from .predictor_graph import PredictorGraph
-from .sampling import apply_repetition_penalty, sample_logits
+from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
 
 
@@ -61,11 +59,7 @@ def fast_generate_streaming(
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
 
-    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
-    suppress_start = max(0, vocab_size - 1024)
-    for i in range(suppress_start, vocab_size):
-        if i != eos_id:
-            suppress_mask[i] = True
+    suppress_mask = build_suppress_mask(vocab_size, eos_id, device=device)
 
     continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
     signature = model_signature(
@@ -80,7 +74,7 @@ def fast_generate_streaming(
     )
     if (
         continuation_state is not None
-        and continuation_state["non_streaming_mode"] != bool(continuation_non_streaming_mode)
+        and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
     ):
         raise ValueError(
             "continuation_state non_streaming_mode does not match the current request"
@@ -96,67 +90,16 @@ def fast_generate_streaming(
 
     # === PREFILL (still uses HF forward for variable-length prefill) ===
     t_start = time.time()
-    full_attention_mask = attention_mask
-    if continuation_state is None:
-        out = talker.forward(
-            inputs_embeds=talker_input_embeds,
-            attention_mask=attention_mask,
-            use_cache=True,
-            output_hidden_states=True,
-            return_dict=True,
-            trailing_text_hidden=trailing_text_hiddens,
-            tts_pad_embed=tts_pad_embed,
-            generation_step=None,
-            past_hidden=None,
-            past_key_values=None,
-        )
-    else:
-        prefix_len = int(talker_input_embeds.shape[1])
-        required_len = base_seq_len + prefix_len
-        if required_len >= talker_graph.max_seq_len - 1:
-            raise RuntimeError(
-                "Continuation prefill exceeds max_seq_len. Reset the continuation state "
-                "or increase max_seq_len."
-            )
-        full_attention_mask = torch.ones(
-            attention_mask.shape[0],
-            required_len,
-            dtype=attention_mask.dtype,
-            device=attention_mask.device,
-        )
-        prefix_cache_position = torch.arange(
-            base_seq_len,
-            required_len,
-            device=device,
-        )
-        prefix_input_ids = torch.zeros(
-            (talker_input_embeds.shape[0], prefix_len),
-            dtype=torch.long,
-            device=device,
-        )
-        talker.rope_deltas = continuation_state["rope_deltas"].to(
-            device=talker_input_embeds.device,
-            dtype=torch.float32,
-        )
-        dynamic_cache = continuation_state_to_dynamic_cache(
-            continuation_state,
-            config=talker.config,
-            device=device,
-        )
-        out = talker.forward(
-            input_ids=prefix_input_ids,
-            inputs_embeds=talker_input_embeds,
-            attention_mask=full_attention_mask,
-            use_cache=True,
-            output_hidden_states=True,
-            return_dict=True,
-            trailing_text_hidden=trailing_text_hiddens,
-            tts_pad_embed=tts_pad_embed,
-            generation_step=None,
-            past_hidden=None,
-            past_key_values=dynamic_cache,
-            cache_position=prefix_cache_position,
-        )
+    out, full_attention_mask, base_seq_len = prefill_with_continuation(
+        talker=talker,
+        talker_input_embeds=talker_input_embeds,
+        attention_mask=attention_mask,
+        trailing_text_hiddens=trailing_text_hiddens,
+        tts_pad_embed=tts_pad_embed,
+        continuation_state=continuation_state,
+        max_seq_len=talker_graph.max_seq_len,
+        device=device,
+    )
 
     talker_past_kv = out.past_key_values
     past_hidden = out.past_hidden
@@ -259,8 +202,11 @@ def fast_generate_streaming(
             }
             if continuation_return_mode != "none":
                 seq_len = prefill_len + total_steps
-                delta = build_continuation_state_delta(
-                    static_cache=talker_graph.static_cache,
+                running_state = attach_continuation_result(
+                    timing=timing,
+                    continuation_return_mode=continuation_return_mode,
+                    running_state=running_state,
+                    cache_source=talker_graph.static_cache,
                     base_seq_len=last_export_seq_len,
                     seq_len=seq_len,
                     rope_deltas=talker_graph.rope_deltas,
@@ -270,14 +216,6 @@ def fast_generate_streaming(
                     non_streaming_mode=continuation_non_streaming_mode,
                     model_signature_dict=signature,
                     device=continuation_state_device,
-                )
-                if continuation_return_mode == "delta":
-                    timing["continuation_state_delta"] = delta
-                else:
-                    running_state = apply_continuation_state_delta(running_state, delta)
-                    timing["continuation_state"] = running_state
-                timing["continuation_state_status"] = build_continuation_state_status(
-                    seq_len=seq_len,
                     max_seq_len=talker_graph.max_seq_len,
                 )
                 last_export_seq_len = seq_len
@@ -304,8 +242,11 @@ def fast_generate_streaming(
         }
         if continuation_return_mode != "none":
             seq_len = prefill_len + total_steps
-            delta = build_continuation_state_delta(
-                static_cache=talker_graph.static_cache,
+            running_state = attach_continuation_result(
+                timing=timing,
+                continuation_return_mode=continuation_return_mode,
+                running_state=running_state,
+                cache_source=talker_graph.static_cache,
                 base_seq_len=last_export_seq_len,
                 seq_len=seq_len,
                 rope_deltas=talker_graph.rope_deltas,
@@ -315,14 +256,6 @@ def fast_generate_streaming(
                 non_streaming_mode=continuation_non_streaming_mode,
                 model_signature_dict=signature,
                 device=continuation_state_device,
-            )
-            if continuation_return_mode == "delta":
-                timing["continuation_state_delta"] = delta
-            else:
-                running_state = apply_continuation_state_delta(running_state, delta)
-                timing["continuation_state"] = running_state
-            timing["continuation_state_status"] = build_continuation_state_status(
-                seq_len=seq_len,
                 max_seq_len=talker_graph.max_seq_len,
             )
 
@@ -350,6 +283,7 @@ def parity_generate_streaming(
     continuation_mode: str = "voice_clone",
     continuation_non_streaming_mode: bool = False,
     continuation_state_device: str = "cpu",
+    continuation_max_seq_len: int | None = None,
 ) -> Generator[Tuple[torch.Tensor, dict], None, None]:
     """
     Streaming generation without CUDA graphs (dynamic cache).
@@ -364,11 +298,7 @@ def parity_generate_streaming(
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
 
-    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
-    suppress_start = max(0, vocab_size - 1024)
-    for i in range(suppress_start, vocab_size):
-        if i != eos_id:
-            suppress_mask[i] = True
+    suppress_mask = build_suppress_mask(vocab_size, eos_id, device=device)
 
     continuation_return_mode = normalize_return_continuation_state(return_continuation_state)
     if continuation_max_seq_len is None:
@@ -389,7 +319,7 @@ def parity_generate_streaming(
     )
     if (
         continuation_state is not None
-        and continuation_state["non_streaming_mode"] != bool(continuation_non_streaming_mode)
+        and continuation_state["non_streaming_mode"] != continuation_non_streaming_mode
     ):
         raise ValueError(
             "continuation_state non_streaming_mode does not match the current request"
@@ -399,67 +329,16 @@ def parity_generate_streaming(
 
     # === PREFILL ===
     t_start = time.time()
-    full_attention_mask = attention_mask
-    if continuation_state is None:
-        out = talker.forward(
-            inputs_embeds=talker_input_embeds,
-            attention_mask=attention_mask,
-            use_cache=True,
-            output_hidden_states=True,
-            return_dict=True,
-            trailing_text_hidden=trailing_text_hiddens,
-            tts_pad_embed=tts_pad_embed,
-            generation_step=None,
-            past_hidden=None,
-            past_key_values=None,
-        )
-    else:
-        prefix_len = int(talker_input_embeds.shape[1])
-        required_len = base_seq_len + prefix_len
-        if required_len >= continuation_max_seq_len - 1:
-            raise RuntimeError(
-                "Continuation prefill exceeds max_seq_len. Reset the continuation state "
-                "or increase max_seq_len."
-            )
-        full_attention_mask = torch.ones(
-            attention_mask.shape[0],
-            required_len,
-            dtype=attention_mask.dtype,
-            device=attention_mask.device,
-        )
-        prefix_cache_position = torch.arange(
-            base_seq_len,
-            required_len,
-            device=device,
-        )
-        prefix_input_ids = torch.zeros(
-            (talker_input_embeds.shape[0], prefix_len),
-            dtype=torch.long,
-            device=device,
-        )
-        talker.rope_deltas = continuation_state["rope_deltas"].to(
-            device=talker_input_embeds.device,
-            dtype=torch.float32,
-        )
-        talker_past_kv = continuation_state_to_dynamic_cache(
-            continuation_state,
-            config=talker.config,
-            device=device,
-        )
-        out = talker.forward(
-            input_ids=prefix_input_ids,
-            inputs_embeds=talker_input_embeds,
-            attention_mask=full_attention_mask,
-            use_cache=True,
-            output_hidden_states=True,
-            return_dict=True,
-            trailing_text_hidden=trailing_text_hiddens,
-            tts_pad_embed=tts_pad_embed,
-            generation_step=None,
-            past_hidden=None,
-            past_key_values=talker_past_kv,
-            cache_position=prefix_cache_position,
-        )
+    out, full_attention_mask, base_seq_len = prefill_with_continuation(
+        talker=talker,
+        talker_input_embeds=talker_input_embeds,
+        attention_mask=attention_mask,
+        trailing_text_hiddens=trailing_text_hiddens,
+        tts_pad_embed=tts_pad_embed,
+        continuation_state=continuation_state,
+        max_seq_len=continuation_max_seq_len,
+        device=device,
+    )
 
     talker_past_kv = out.past_key_values
     past_hidden = out.past_hidden
@@ -566,8 +445,11 @@ def parity_generate_streaming(
             }
             if continuation_return_mode != "none":
                 seq_len = int(attention_mask.shape[1]) if attention_mask is not None else base_seq_len + total_steps
-                delta = build_continuation_state_delta(
-                    static_cache=talker_past_kv,
+                running_state = attach_continuation_result(
+                    timing=timing,
+                    continuation_return_mode=continuation_return_mode,
+                    running_state=running_state,
+                    cache_source=talker_past_kv,
                     base_seq_len=last_export_seq_len,
                     seq_len=seq_len,
                     rope_deltas=talker.rope_deltas,
@@ -577,14 +459,6 @@ def parity_generate_streaming(
                     non_streaming_mode=continuation_non_streaming_mode,
                     model_signature_dict=signature,
                     device=continuation_state_device,
-                )
-                if continuation_return_mode == "delta":
-                    timing["continuation_state_delta"] = delta
-                else:
-                    running_state = apply_continuation_state_delta(running_state, delta)
-                    timing["continuation_state"] = running_state
-                timing["continuation_state_status"] = build_continuation_state_status(
-                    seq_len=seq_len,
                     max_seq_len=continuation_max_seq_len,
                 )
                 last_export_seq_len = seq_len
@@ -610,8 +484,11 @@ def parity_generate_streaming(
         }
         if continuation_return_mode != "none":
             seq_len = int(attention_mask.shape[1]) if attention_mask is not None else base_seq_len + total_steps
-            delta = build_continuation_state_delta(
-                static_cache=talker_past_kv,
+            running_state = attach_continuation_result(
+                timing=timing,
+                continuation_return_mode=continuation_return_mode,
+                running_state=running_state,
+                cache_source=talker_past_kv,
                 base_seq_len=last_export_seq_len,
                 seq_len=seq_len,
                 rope_deltas=talker.rope_deltas,
@@ -621,14 +498,6 @@ def parity_generate_streaming(
                 non_streaming_mode=continuation_non_streaming_mode,
                 model_signature_dict=signature,
                 device=continuation_state_device,
-            )
-            if continuation_return_mode == "delta":
-                timing["continuation_state_delta"] = delta
-            else:
-                running_state = apply_continuation_state_delta(running_state, delta)
-                timing["continuation_state"] = running_state
-            timing["continuation_state_status"] = build_continuation_state_status(
-                seq_len=seq_len,
                 max_seq_len=continuation_max_seq_len,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["faster_qwen3_tts*"]
 
 [project]
 name = "faster-qwen3-tts"
-version = "0.2.6"
+version = "0.3.0"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_continuation_state_api.py
+++ b/tests/test_continuation_state_api.py
@@ -6,6 +6,7 @@ import torch
 from faster_qwen3_tts.continuation import (
     apply_continuation_state_delta,
     build_continuation_state_status,
+    validate_full_continuation_state,
 )
 from faster_qwen3_tts.model import FasterQwen3TTS
 from faster_qwen3_tts.streaming import parity_generate_streaming
@@ -94,6 +95,14 @@ def test_apply_continuation_state_delta_rejects_version_mismatch():
         apply_continuation_state_delta(None, delta)
 
 
+def test_apply_continuation_state_delta_rejects_cache_layer_count_mismatch():
+    delta = _delta(base_seq_len=0, added_seq_len=2, value=5)
+    delta["cache_delta"] = delta["cache_delta"][:1]
+
+    with pytest.raises(ValueError, match="cache_delta.*expected 2, got 1"):
+        apply_continuation_state_delta(None, delta)
+
+
 def test_apply_continuation_state_delta_rejects_seq_len_mismatch():
     state = apply_continuation_state_delta(None, _delta(base_seq_len=0, added_seq_len=2, value=5))
 
@@ -124,6 +133,18 @@ def test_build_continuation_state_status_warns_near_limit():
     assert status["remaining_tokens"] == 247
     assert status["should_reset"] is True
     assert "warning" in status
+
+
+def test_validate_full_continuation_state_rejects_cache_layer_count_mismatch():
+    state = apply_continuation_state_delta(None, _delta(base_seq_len=0, added_seq_len=2, value=5))
+    state["cache"] = state["cache"][:1]
+
+    with pytest.raises(ValueError, match="expected 2, got 1"):
+        validate_full_continuation_state(
+            state,
+            mode="custom_voice",
+            expected_signature=state["model_signature"],
+        )
 
 
 def test_generate_voice_clone_returns_info_when_continuation_requested(monkeypatch):

--- a/tests/test_continuation_state_api.py
+++ b/tests/test_continuation_state_api.py
@@ -6,6 +6,7 @@ import torch
 from faster_qwen3_tts.continuation import (
     apply_continuation_state_delta,
     build_continuation_state_status,
+    normalize_return_continuation_state,
     validate_full_continuation_state,
 )
 from faster_qwen3_tts.model import FasterQwen3TTS
@@ -29,6 +30,37 @@ def _build_wrapper():
     model = FasterQwen3TTS(base, _dummy_graph(), _dummy_graph(), device="cpu", dtype=torch.float32)
     model._warmup = lambda _prefill_len: setattr(model, "_warmed_up", True)
     return model
+
+
+def _fake_speech_tokenizer():
+    return types.SimpleNamespace(
+        decode=lambda _payload: ([torch.arange(24, dtype=torch.float32)], 24000)
+    )
+
+
+def _fake_prepare_generation(*_args, **_kwargs):
+    return (
+        types.SimpleNamespace(speech_tokenizer=_fake_speech_tokenizer()),
+        object(),
+        object(),
+        torch.zeros(1, 1, 1),
+        torch.ones(1, 1, dtype=torch.long),
+        torch.zeros(1, 1, 1),
+        torch.zeros(1, 1, 1),
+        None,
+    )
+
+
+def _fake_prepare_generation_custom(*_args, **_kwargs):
+    return (
+        types.SimpleNamespace(speech_tokenizer=_fake_speech_tokenizer()),
+        object(),
+        object(),
+        torch.zeros(1, 1, 1),
+        torch.ones(1, 1, dtype=torch.long),
+        torch.zeros(1, 1, 1),
+        torch.zeros(1, 1, 1),
+    )
 
 
 def _delta(*, base_seq_len, added_seq_len, value):
@@ -147,6 +179,10 @@ def test_validate_full_continuation_state_rejects_cache_layer_count_mismatch():
         )
 
 
+def test_normalize_return_continuation_state_accepts_internal_none_mode():
+    assert normalize_return_continuation_state("none") == "none"
+
+
 def test_generate_voice_clone_returns_info_when_continuation_requested(monkeypatch):
     model = _build_wrapper()
     timing = {
@@ -245,6 +281,184 @@ def test_generate_custom_voice_streaming_keeps_continuation_delta_in_timing(monk
     assert chunk.ndim == 1
     assert timing["continuation_state_delta"] == {"delta": True}
     assert timing["continuation_state_status"] == {"remaining_tokens": 55}
+
+
+def test_generate_custom_voice_default_return_mode_still_works(monkeypatch):
+    model = _build_wrapper()
+    model.model.model.tts_model_type = "custom_voice"
+
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation_custom",
+        lambda **_kwargs: (
+            types.SimpleNamespace(
+                speech_tokenizer=types.SimpleNamespace(
+                    decode=lambda _payload: ([torch.arange(16, dtype=torch.float32)], 24000)
+                )
+            ),
+            object(),
+            object(),
+            torch.zeros(1, 1, 1),
+            torch.ones(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, 1),
+            torch.zeros(1, 1, 1),
+        ),
+    )
+
+    captured = {}
+
+    def _fake_generate(**kwargs):
+        captured["return_continuation_state"] = kwargs["return_continuation_state"]
+        return torch.zeros(2, 16, dtype=torch.long), {
+            "prefill_ms": 0.0,
+            "decode_s": 0.01,
+            "steps": 2,
+            "ms_per_step": 5.0,
+            "steps_per_s": 200.0,
+        }
+
+    monkeypatch.setattr("faster_qwen3_tts.generate.fast_generate", _fake_generate)
+
+    audio, sr = model.generate_custom_voice(
+        text="hello",
+        speaker="speaker_a",
+        language="English",
+        do_sample=False,
+    )
+
+    assert sr == 24000
+    assert len(audio) == 1
+    assert captured["return_continuation_state"] == "none"
+
+
+@pytest.mark.parametrize(
+    ("method_name", "model_type", "kwargs"),
+    [
+        (
+            "generate_voice_clone",
+            "base",
+            {
+                "text": "hello",
+                "language": "English",
+                "voice_clone_prompt": {"ref_spk_embedding": [torch.zeros(1, 4)]},
+                "do_sample": False,
+            },
+        ),
+        (
+            "generate_custom_voice",
+            "custom_voice",
+            {
+                "text": "hello",
+                "speaker": "speaker_a",
+                "language": "English",
+                "do_sample": False,
+            },
+        ),
+        (
+            "generate_voice_design",
+            "voice_design",
+            {
+                "text": "hello",
+                "instruct": "Warm and natural.",
+                "language": "English",
+                "do_sample": False,
+            },
+        ),
+    ],
+)
+def test_nonstream_wrappers_default_return_mode_contract(monkeypatch, method_name, model_type, kwargs):
+    model = _build_wrapper()
+    model.model.model.tts_model_type = model_type
+
+    monkeypatch.setattr(model, "_prepare_generation", _fake_prepare_generation)
+    monkeypatch.setattr(model, "_prepare_generation_custom", _fake_prepare_generation_custom)
+
+    captured = {}
+
+    def _fake_generate(**call_kwargs):
+        captured["return_continuation_state"] = call_kwargs["return_continuation_state"]
+        return torch.zeros(2, 16, dtype=torch.long), {
+            "prefill_ms": 0.0,
+            "decode_s": 0.01,
+            "steps": 2,
+            "ms_per_step": 5.0,
+            "steps_per_s": 200.0,
+        }
+
+    monkeypatch.setattr("faster_qwen3_tts.generate.fast_generate", _fake_generate)
+
+    result = getattr(model, method_name)(**kwargs)
+
+    assert len(result) == 2
+    audio, sr = result
+    assert len(audio) == 1
+    assert sr == 24000
+    assert captured["return_continuation_state"] == "none"
+
+
+@pytest.mark.parametrize(
+    ("method_name", "model_type", "kwargs"),
+    [
+        (
+            "generate_voice_clone_streaming",
+            "base",
+            {
+                "text": "hello",
+                "language": "English",
+                "voice_clone_prompt": {"ref_spk_embedding": [torch.zeros(1, 4)]},
+                "do_sample": False,
+            },
+        ),
+        (
+            "generate_custom_voice_streaming",
+            "custom_voice",
+            {
+                "text": "hello",
+                "speaker": "speaker_a",
+                "language": "English",
+                "do_sample": False,
+            },
+        ),
+        (
+            "generate_voice_design_streaming",
+            "voice_design",
+            {
+                "text": "hello",
+                "instruct": "Warm and natural.",
+                "language": "English",
+                "do_sample": False,
+            },
+        ),
+    ],
+)
+def test_streaming_wrappers_default_return_mode_contract(monkeypatch, method_name, model_type, kwargs):
+    model = _build_wrapper()
+    model.model.model.tts_model_type = model_type
+
+    monkeypatch.setattr(model, "_prepare_generation", _fake_prepare_generation)
+    monkeypatch.setattr(model, "_prepare_generation_custom", _fake_prepare_generation_custom)
+
+    captured = {}
+
+    def _fake_stream(**call_kwargs):
+        captured["return_continuation_state"] = call_kwargs["return_continuation_state"]
+        yield torch.zeros(2, 16, dtype=torch.long), {
+            "chunk_index": 0,
+            "chunk_steps": 2,
+            "prefill_ms": 0.0,
+            "decode_ms": 1.0,
+            "total_steps_so_far": 2,
+            "is_final": True,
+        }
+
+    monkeypatch.setattr("faster_qwen3_tts.streaming.fast_generate_streaming", _fake_stream)
+
+    chunk, sr, timing = next(getattr(model, method_name)(**kwargs))
+
+    assert chunk.ndim == 1
+    assert sr == 24000
+    assert timing["is_final"] is True
+    assert captured["return_continuation_state"] is False
 
 
 def test_parity_generate_streaming_smoke_with_continuation(monkeypatch):

--- a/tests/test_continuation_state_api.py
+++ b/tests/test_continuation_state_api.py
@@ -8,6 +8,7 @@ from faster_qwen3_tts.continuation import (
     build_continuation_state_status,
 )
 from faster_qwen3_tts.model import FasterQwen3TTS
+from faster_qwen3_tts.streaming import parity_generate_streaming
 
 
 def _dummy_graph():
@@ -69,6 +70,53 @@ def test_apply_continuation_state_delta_builds_and_extends_state():
     assert state["first_codebook_history"].tolist() == [5, 6, 9, 10]
     assert torch.all(state["cache"][0]["key"][:, :, :3, :] == 5)
     assert torch.all(state["cache"][0]["key"][:, :, 3:, :] == 9)
+
+
+def test_apply_continuation_state_delta_rejects_nonzero_base_without_state():
+    with pytest.raises(ValueError, match="base_seq_len is non-zero"):
+        apply_continuation_state_delta(None, _delta(base_seq_len=3, added_seq_len=2, value=5))
+
+
+def test_apply_continuation_state_delta_rejects_mode_mismatch():
+    state = apply_continuation_state_delta(None, _delta(base_seq_len=0, added_seq_len=2, value=5))
+    delta = _delta(base_seq_len=2, added_seq_len=1, value=7)
+    delta["mode"] = "voice_clone"
+
+    with pytest.raises(ValueError, match="mode mismatch"):
+        apply_continuation_state_delta(state, delta)
+
+
+def test_apply_continuation_state_delta_rejects_version_mismatch():
+    delta = _delta(base_seq_len=0, added_seq_len=2, value=5)
+    delta["version"] = 999
+
+    with pytest.raises(ValueError, match="Unsupported continuation delta version"):
+        apply_continuation_state_delta(None, delta)
+
+
+def test_apply_continuation_state_delta_rejects_seq_len_mismatch():
+    state = apply_continuation_state_delta(None, _delta(base_seq_len=0, added_seq_len=2, value=5))
+
+    with pytest.raises(ValueError, match="base_seq_len"):
+        apply_continuation_state_delta(state, _delta(base_seq_len=3, added_seq_len=1, value=7))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for mixed-device merge test")
+def test_apply_continuation_state_delta_moves_delta_to_state_device():
+    state = apply_continuation_state_delta(None, _delta(base_seq_len=0, added_seq_len=2, value=5))
+    delta = _delta(base_seq_len=2, added_seq_len=1, value=7)
+    delta["rope_deltas"] = delta["rope_deltas"].to("cuda")
+    delta["first_codebook_history_delta"] = delta["first_codebook_history_delta"].to("cuda")
+    delta["codec_ids_delta"] = delta["codec_ids_delta"].to("cuda")
+    for layer in delta["cache_delta"]:
+        layer["key"] = layer["key"].to("cuda")
+        layer["value"] = layer["value"].to("cuda")
+
+    merged = apply_continuation_state_delta(state, delta)
+
+    assert merged["rope_deltas"].device.type == "cpu"
+    assert merged["first_codebook_history"].device.type == "cpu"
+    assert merged["decoder_context_codes"].device.type == "cpu"
 
 
 def test_build_continuation_state_status_warns_near_limit():
@@ -176,3 +224,49 @@ def test_generate_custom_voice_streaming_keeps_continuation_delta_in_timing(monk
     assert chunk.ndim == 1
     assert timing["continuation_state_delta"] == {"delta": True}
     assert timing["continuation_state_status"] == {"remaining_tokens": 55}
+
+
+def test_parity_generate_streaming_smoke_with_continuation(monkeypatch):
+    delta = _delta(base_seq_len=0, added_seq_len=2, value=5)
+    delta["mode"] = "voice_clone"
+    state = apply_continuation_state_delta(None, delta)
+
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        "faster_qwen3_tts.streaming.prefill_with_continuation",
+        lambda **_kwargs: (
+            types.SimpleNamespace(
+                past_key_values=types.SimpleNamespace(layers=[]),
+                past_hidden=torch.zeros(1, 1, 4),
+                generation_step=0,
+                logits=torch.zeros(1, 1, 32),
+            ),
+            torch.ones(1, state["seq_len"] + 1, dtype=torch.long),
+            state["seq_len"],
+        ),
+    )
+
+    talker = types.SimpleNamespace(
+        config=types.SimpleNamespace(num_hidden_layers=2, hidden_size=4),
+        rope_deltas=torch.zeros(1, 1),
+    )
+    config = types.SimpleNamespace(codec_eos_token_id=31, vocab_size=32)
+
+    result = list(
+        parity_generate_streaming(
+            talker=talker,
+            talker_input_embeds=torch.zeros(1, 1, 4),
+            attention_mask=torch.ones(1, 1, dtype=torch.long),
+            trailing_text_hiddens=torch.zeros(1, 1, 4),
+            tts_pad_embed=torch.zeros(1, 1, 4),
+            config=config,
+            max_new_tokens=0,
+            do_sample=False,
+            continuation_state=state,
+            continuation_mode="voice_clone",
+            continuation_non_streaming_mode=False,
+            continuation_max_seq_len=64,
+        )
+    )
+
+    assert result == []

--- a/tests/test_continuation_state_api.py
+++ b/tests/test_continuation_state_api.py
@@ -1,0 +1,178 @@
+import types
+
+import pytest
+import torch
+
+from faster_qwen3_tts.continuation import (
+    apply_continuation_state_delta,
+    build_continuation_state_status,
+)
+from faster_qwen3_tts.model import FasterQwen3TTS
+
+
+def _dummy_graph():
+    return types.SimpleNamespace(num_layers=2, max_seq_len=64, hidden_size=4)
+
+
+def _build_wrapper():
+    base = types.SimpleNamespace()
+    base.model = types.SimpleNamespace(
+        talker=types.SimpleNamespace(rope_deltas=None),
+        config=types.SimpleNamespace(talker_config=types.SimpleNamespace()),
+        tts_model_size="1b7",
+        tts_model_type="base",
+    )
+    base._validate_languages = lambda _languages: None
+    base._validate_speakers = lambda _speakers: None
+    model = FasterQwen3TTS(base, _dummy_graph(), _dummy_graph(), device="cpu", dtype=torch.float32)
+    model._warmup = lambda _prefill_len: setattr(model, "_warmed_up", True)
+    return model
+
+
+def _delta(*, base_seq_len, added_seq_len, value):
+    key = torch.full((1, 1, added_seq_len, 2), value, dtype=torch.float32)
+    val = torch.full((1, 1, added_seq_len, 2), value + 10, dtype=torch.float32)
+    return {
+        "version": 1,
+        "state_kind": "delta",
+        "mode": "custom_voice",
+        "non_streaming_mode": False,
+        "model_signature": {
+            "num_layers": 2,
+            "max_seq_len": 64,
+            "hidden_size": 4,
+        },
+        "base_seq_len": base_seq_len,
+        "seq_len": base_seq_len + added_seq_len,
+        "added_seq_len": added_seq_len,
+        "cache_delta": [
+            {"key": key.clone(), "value": val.clone()},
+            {"key": key.clone() + 1, "value": val.clone() + 1},
+        ],
+        "rope_deltas": torch.zeros(1, 1, dtype=torch.float32),
+        "first_codebook_history_delta": torch.tensor([value, value + 1], dtype=torch.long),
+        "codec_ids_delta": torch.full((2, 16), value, dtype=torch.long),
+    }
+
+
+def test_apply_continuation_state_delta_builds_and_extends_state():
+    state = apply_continuation_state_delta(None, _delta(base_seq_len=0, added_seq_len=3, value=5))
+    assert state["state_kind"] == "full"
+    assert state["seq_len"] == 3
+    assert state["cache"][0]["key"].shape == (1, 1, 3, 2)
+    assert state["first_codebook_history"].tolist() == [5, 6]
+    assert state["decoder_context_codes"].shape == (2, 16)
+
+    state = apply_continuation_state_delta(state, _delta(base_seq_len=3, added_seq_len=2, value=9))
+    assert state["seq_len"] == 5
+    assert state["cache"][0]["key"].shape == (1, 1, 5, 2)
+    assert state["first_codebook_history"].tolist() == [5, 6, 9, 10]
+    assert torch.all(state["cache"][0]["key"][:, :, :3, :] == 5)
+    assert torch.all(state["cache"][0]["key"][:, :, 3:, :] == 9)
+
+
+def test_build_continuation_state_status_warns_near_limit():
+    status = build_continuation_state_status(seq_len=1800, max_seq_len=2048)
+    assert status["remaining_tokens"] == 247
+    assert status["should_reset"] is True
+    assert "warning" in status
+
+
+def test_generate_voice_clone_returns_info_when_continuation_requested(monkeypatch):
+    model = _build_wrapper()
+    timing = {
+        "prefill_ms": 10.0,
+        "decode_s": 0.02,
+        "steps": 3,
+        "ms_per_step": 1.0,
+        "steps_per_s": 1000.0,
+        "continuation_state_delta": {"delta": True},
+        "continuation_state_status": {"remaining_tokens": 123},
+    }
+
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation",
+        lambda **_kwargs: (
+            types.SimpleNamespace(
+                speech_tokenizer=types.SimpleNamespace(
+                    decode=lambda _payload: ([torch.arange(12, dtype=torch.float32)], 24000)
+                )
+            ),
+            object(),
+            object(),
+            torch.zeros(1, 1, 1),
+            torch.ones(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, 1),
+            torch.zeros(1, 1, 1),
+            None,
+        ),
+    )
+
+    monkeypatch.setattr(
+        "faster_qwen3_tts.generate.fast_generate",
+        lambda **_kwargs: (torch.zeros(3, 16, dtype=torch.long), timing),
+    )
+
+    audio, sr, info = model.generate_voice_clone(
+        text="hello",
+        language="English",
+        voice_clone_prompt={"ref_spk_embedding": [torch.zeros(1, 4)]},
+        return_continuation_state=True,
+    )
+
+    assert sr == 24000
+    assert len(audio) == 1
+    assert info["continuation_state_delta"] == {"delta": True}
+    assert info["continuation_state_status"] == {"remaining_tokens": 123}
+
+
+def test_generate_custom_voice_streaming_keeps_continuation_delta_in_timing(monkeypatch):
+    model = _build_wrapper()
+    model.model.model.tts_model_type = "custom_voice"
+
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation_custom",
+        lambda **_kwargs: (
+            types.SimpleNamespace(
+                speech_tokenizer=types.SimpleNamespace(
+                    decode=lambda _payload: ([torch.arange(16, dtype=torch.float32)], 24000)
+                )
+            ),
+            object(),
+            object(),
+            torch.zeros(1, 1, 1),
+            torch.ones(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, 1),
+            torch.zeros(1, 1, 1),
+        ),
+    )
+
+    def _fake_stream(**_kwargs):
+        yield torch.zeros(2, 16, dtype=torch.long), {
+            "chunk_index": 0,
+            "chunk_steps": 2,
+            "prefill_ms": 0.0,
+            "decode_ms": 1.0,
+            "total_steps_so_far": 2,
+            "is_final": True,
+            "continuation_state_delta": {"delta": True},
+            "continuation_state_status": {"remaining_tokens": 55},
+        }
+
+    monkeypatch.setattr("faster_qwen3_tts.streaming.fast_generate_streaming", _fake_stream)
+
+    chunk, sr, timing = next(
+        model.generate_custom_voice_streaming(
+            text="hello",
+            speaker="speaker_a",
+            language="English",
+            return_continuation_state=True,
+        )
+    )
+
+    assert sr == 24000
+    assert chunk.ndim == 1
+    assert timing["continuation_state_delta"] == {"delta": True}
+    assert timing["continuation_state_status"] == {"remaining_tokens": 55}

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -59,10 +59,23 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     sig_stream = inspect.signature(FasterQwen3TTS.generate_voice_clone_streaming)
     assert "voice_clone_prompt" in sig_clone.parameters
     assert "voice_clone_prompt" in sig_stream.parameters
+    assert "continuation_state" in sig_clone.parameters
+    assert "continuation_state" in sig_stream.parameters
+    assert "return_continuation_state" in sig_clone.parameters
+    assert "return_continuation_state" in sig_stream.parameters
     assert list(sig_clone.parameters).index("max_new_tokens") == 5
     assert list(sig_stream.parameters).index("max_new_tokens") == 5
-    assert list(sig_clone.parameters)[-1] == "voice_clone_prompt"
-    assert list(sig_stream.parameters)[-1] == "voice_clone_prompt"
+    assert list(sig_clone.parameters)[-4:] == [
+        "voice_clone_prompt",
+        "continuation_state",
+        "return_continuation_state",
+        "continuation_state_device",
+    ]
+    assert list(sig_stream.parameters)[-3:] == [
+        "continuation_state",
+        "return_continuation_state",
+        "continuation_state_device",
+    ]
     assert sig_clone.parameters["xvec_only"].default is False
     assert sig_clone.parameters["non_streaming_mode"].default is None
     assert sig_stream.parameters["xvec_only"].default is False
@@ -79,6 +92,10 @@ def test_public_api_uses_none_sentinel_for_non_streaming_overrides():
     assert sig_custom_stream.parameters["non_streaming_mode"].default is None
     assert sig_design.parameters["non_streaming_mode"].default is None
     assert sig_design_stream.parameters["non_streaming_mode"].default is None
+    for sig in (sig_custom, sig_custom_stream, sig_design, sig_design_stream):
+        assert "continuation_state" in sig.parameters
+        assert "return_continuation_state" in sig.parameters
+        assert "continuation_state_device" in sig.parameters
 
 
 @pytest.mark.parametrize(

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from faster_qwen3_tts.model import FasterQwen3TTS
+from faster_qwen3_tts.streaming import parity_generate_streaming
 
 
 def _dummy_graph():
@@ -57,12 +58,14 @@ def _xvec_prompt():
 def test_public_api_exposes_voice_clone_prompt_parameter():
     sig_clone = inspect.signature(FasterQwen3TTS.generate_voice_clone)
     sig_stream = inspect.signature(FasterQwen3TTS.generate_voice_clone_streaming)
+    sig_parity_stream = inspect.signature(parity_generate_streaming)
     assert "voice_clone_prompt" in sig_clone.parameters
     assert "voice_clone_prompt" in sig_stream.parameters
     assert "continuation_state" in sig_clone.parameters
     assert "continuation_state" in sig_stream.parameters
     assert "return_continuation_state" in sig_clone.parameters
     assert "return_continuation_state" in sig_stream.parameters
+    assert "continuation_max_seq_len" in sig_parity_stream.parameters
     assert list(sig_clone.parameters).index("max_new_tokens") == 5
     assert list(sig_stream.parameters).index("max_new_tokens") == 5
     assert list(sig_clone.parameters)[-4:] == [
@@ -80,6 +83,57 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     assert sig_clone.parameters["non_streaming_mode"].default is None
     assert sig_stream.parameters["xvec_only"].default is False
     assert sig_stream.parameters["non_streaming_mode"].default is None
+
+
+def test_generate_voice_clone_streaming_parity_passes_continuation_max_seq_len(monkeypatch):
+    model = _build_dummy_model()
+    captured = {}
+
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation",
+        lambda **_kwargs: (
+            types.SimpleNamespace(
+                speech_tokenizer=types.SimpleNamespace(
+                    decode=lambda _payload: ([torch.arange(16, dtype=torch.float32)], 24000)
+                )
+            ),
+            object(),
+            object(),
+            torch.zeros(1, 1, 1),
+            torch.ones(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, 1),
+            torch.zeros(1, 1, 1),
+            None,
+        ),
+    )
+
+    def _fake_parity_stream(**kwargs):
+        captured["continuation_max_seq_len"] = kwargs["continuation_max_seq_len"]
+        yield torch.zeros(2, 16, dtype=torch.long), {
+            "chunk_index": 0,
+            "chunk_steps": 2,
+            "prefill_ms": 0.0,
+            "decode_ms": 1.0,
+            "total_steps_so_far": 2,
+            "is_final": True,
+        }
+
+    monkeypatch.setattr("faster_qwen3_tts.streaming.parity_generate_streaming", _fake_parity_stream)
+
+    chunk, sr, timing = next(
+        model.generate_voice_clone_streaming(
+            text="hello",
+            language="English",
+            voice_clone_prompt=_xvec_prompt(),
+            parity_mode=True,
+        )
+    )
+
+    assert captured["continuation_max_seq_len"] == model.max_seq_len
+    assert sr == 24000
+    assert chunk.ndim == 1
+    assert timing["chunk_index"] == 0
 
 
 def test_public_api_uses_none_sentinel_for_non_streaming_overrides():


### PR DESCRIPTION
## What changed

This adds a caller-owned continuation-state API for follow-up turns across all public generation modes:

- `generate_voice_clone`
- `generate_voice_clone_streaming`
- `generate_custom_voice`
- `generate_custom_voice_streaming`
- `generate_voice_design`
- `generate_voice_design_streaming`

The generators can now return a full continuation state on the first turn, return delta-only state updates on later turns, and accept a previously returned full state to continue from existing talker cache state instead of restarting cold.

The implementation also carries decoder left-context forward so chunk/audio boundaries do not decode with a cold codec context, and it adds `continuation_state_status` metadata so callers can warn or reset before hitting `max_seq_len`.

## Why it changed

When an application synthesizes multi-sentence LLM output incrementally, restarting TTS from scratch on each sentence makes the follow-up sentence sound detached from the previous one. The goal here is to let callers preserve enough internal state to continue naturally across turns while keeping the state caller-owned so servers can multiplex or persist it externally.

## Impact

- Improves continuity across separately generated turns
- Works for Base voice clone, CustomVoice, and VoiceDesign
- Works for both streaming and non-streaming audio output
- Lets callers merge only newly generated cache rows with `apply_continuation_state_delta(...)`
- Adds `benchmarks/continuation.py` to measure fresh vs continuation follow-up latency
- Documents the new API in the README

## Validation

- `./.venv/bin/pytest tests/test_continuation_state_api.py tests/test_voice_clone_prompt_api.py -q`
- `./.venv/bin/python -m compileall faster_qwen3_tts`
- GPU smoke tests for `custom_voice`, `voice_clone`, and `voice_design` in streaming and non-streaming continuation paths
- Quick benchmark sanity checks on this machine:
  - `custom_voice`: TTFA `419 ms -> 317 ms`, non-stream latency `2726 ms -> 2421 ms`
  - `voice_clone`: TTFA `381 ms -> 312 ms`, non-stream latency `1893 ms -> 2000 ms`
  - `voice_design`: TTFA `456 ms -> 402 ms`, non-stream latency `2077 ms -> 2077 ms`

## Notes

There is still no cache compaction/sliding-window truncation for long continuation sessions. Instead, the API now returns `continuation_state_status` so callers can decide when to start a fresh session before the saved state gets too close to `max_seq_len`.
