### PR TITLE
[codex] fix stale parity test assumptions

### DIFF
--- a/tests/test_e2e_parity.py
+++ b/tests/test_e2e_parity.py
@@ -341,6 +341,7 @@ def custom_voice_fixture():
         language=language,
         speaker=speaker,
         instruct=None,
+        non_streaming_mode=False,
     )
 
     data = dict(
@@ -387,6 +388,7 @@ def voice_design_fixture():
         language=language,
         speaker=None,
         instruct=instruct,
+        non_streaming_mode=False,
     )
 
     data = dict(
@@ -1031,10 +1033,11 @@ def test_instruct_prepends_tokens_to_voice_clone(parity_fixture):
 
     with torch.inference_mode():
         _, _, _, tie_base, tam_base, _, _, _ = fast._prepare_generation(
-            text, ref_audio, "", language=language, non_streaming_mode=False
+            text, ref_audio, "", language=language, non_streaming_mode=False, xvec_only=True
         )
         _, _, _, tie_inst, tam_inst, _, _, _ = fast._prepare_generation(
             text, ref_audio, "", language=language, non_streaming_mode=False,
+            xvec_only=True,
             instruct=instruct_str,
         )
 
@@ -1065,11 +1068,13 @@ def test_instruct_changes_generation_output(parity_fixture):
     with torch.inference_mode():
         wav_base, _ = fast.generate_voice_clone(
             text=text, language=language, ref_audio=ref_audio, ref_text="",
+            xvec_only=True,
             max_new_tokens=32, do_sample=False, top_k=0, top_p=1.0, temperature=1.0,
             repetition_penalty=1.0,
         )
         wav_inst, _ = fast.generate_voice_clone(
             text=text, language=language, ref_audio=ref_audio, ref_text="",
+            xvec_only=True,
             max_new_tokens=32, do_sample=False, top_k=0, top_p=1.0, temperature=1.0,
             repetition_penalty=1.0,
             instruct="Please speak very slowly and with a deep voice.",


### PR DESCRIPTION
## Summary
This fixes the four pre-existing failures on `main` in `tests/test_e2e_parity.py`.

## What changed
- Updated the CustomVoice parity fixture to build fast-path inputs with `non_streaming_mode=False`, matching the upstream parity call.
- Updated the VoiceDesign parity fixture to build fast-path inputs with `non_streaming_mode=False`, matching the upstream parity call.
- Updated the two Base instruct tests to use `xvec_only=True`, which matches their empty `ref_text` setup.

## Root cause
The failing tests were asserting parity across mismatched generation layouts or using a stale voice-clone setup:
- The CustomVoice and VoiceDesign parity fixtures prepared fast inputs with `non_streaming_mode=True` but compared them against upstream `generate(..., non_streaming_mode=False)`.
- The two instruct tests used `ref_text=""` while relying on Base ICL mode semantics, which now correctly require non-empty `ref_text` unless `xvec_only=True`.

## Impact
- The repo's pre-existing red test state on `main` is resolved.
- The parity suite now reflects the actual supported contracts and compares like-for-like inputs.

## Validation
- `./.venv/bin/pytest -q tests/test_e2e_parity.py::TestCustomVoice::test_custom_voice_full_parity_dynamic_cache tests/test_e2e_parity.py::test_instruct_prepends_tokens_to_voice_clone tests/test_e2e_parity.py::test_instruct_changes_generation_output tests/test_e2e_parity.py::TestVoiceDesign::test_voice_design_full_parity_dynamic_cache`
- `./.venv/bin/pytest -q`

Result: `50 passed, 3 warnings`
