### PR TITLE
perf: vectorize suppress_mask build, precompute EOS suppress index

### DIFF
--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple
 import torch
 
 from .predictor_graph import PredictorGraph
-from .sampling import apply_repetition_penalty, sample_logits
+from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
 
 
@@ -43,11 +43,9 @@ def fast_generate(
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
     
-    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
+    suppress_mask = build_suppress_mask(vocab_size, eos_id, device)
     suppress_start = max(0, vocab_size - 1024)
-    for i in range(suppress_start, vocab_size):
-        if i != eos_id:
-            suppress_mask[i] = True
+    eos_suppress_ids = torch.tensor([eos_id], dtype=torch.long, device=device)
 
     if parity_mode:
         suppress_tokens = [i for i in range(suppress_start, vocab_size) if i != eos_id]
@@ -130,7 +128,7 @@ def fast_generate(
         top_p=top_p,
         do_sample=do_sample,
         suppress_mask=suppress_mask,
-        suppress_tokens=[eos_id] if suppress_eos else None,
+        suppress_tokens=eos_suppress_ids if suppress_eos else None,
     )
     
     # Copy prefill KV cache into talker graph's static cache
@@ -193,7 +191,7 @@ def fast_generate(
             top_p=top_p,
             do_sample=do_sample,
             suppress_mask=suppress_mask,
-            suppress_tokens=[eos_id] if suppress_eos else None,
+            suppress_tokens=eos_suppress_ids if suppress_eos else None,
         )
         past_hidden = hidden_states[:, -1:, :].clone()  # clone since it's the static buffer
         gen_step += 1

--- a/faster_qwen3_tts/sampling.py
+++ b/faster_qwen3_tts/sampling.py
@@ -6,6 +6,23 @@ from typing import Iterable, Optional
 import torch
 import torch.nn.functional as F
 
+_SUPPRESS_MASK_CACHE: dict = {}
+
+
+def build_suppress_mask(vocab_size: int, eos_id: int, device) -> torch.Tensor:
+    """Boolean mask over the suppressed special-token tail [vocab-1024, vocab), excluding EOS.
+
+    Cached per (vocab_size, eos_id, device); callers must not mutate the result.
+    """
+    key = (vocab_size, eos_id, str(device))
+    mask = _SUPPRESS_MASK_CACHE.get(key)
+    if mask is None:
+        mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
+        mask[max(0, vocab_size - 1024):] = True
+        mask[eos_id] = False
+        _SUPPRESS_MASK_CACHE[key] = mask
+    return mask
+
 
 def apply_repetition_penalty(
     logits: torch.Tensor,
@@ -37,17 +54,23 @@ def sample_logits(
     top_p: float,
     do_sample: bool,
     suppress_mask: Optional[torch.Tensor] = None,
-    suppress_tokens: Optional[Iterable[int]] = None,
+    suppress_tokens: Optional[Iterable[int] | torch.Tensor] = None,
 ) -> torch.Tensor:
     """Sample a token from logits.
 
     Mirrors HF order: suppress -> temperature -> top-k -> top-p -> sample.
+
+    suppress_tokens may be a 1-D index tensor (preferred in hot loops — avoids a
+    host-to-device copy per call) or any iterable of ints.
     """
     logits = logits.clone()
     if suppress_mask is not None:
         logits[..., suppress_mask] = float("-inf")
-    if suppress_tokens:
-        logits[..., list(suppress_tokens)] = float("-inf")
+    if suppress_tokens is not None:
+        if not isinstance(suppress_tokens, torch.Tensor):
+            suppress_tokens = torch.tensor(list(suppress_tokens), dtype=torch.long, device=logits.device)
+        if suppress_tokens.numel() > 0:
+            logits[..., suppress_tokens] = float("-inf")
     if not do_sample:
         return torch.argmax(logits, dim=-1)
     logits = logits / temperature

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -11,7 +11,7 @@ from typing import Generator, Tuple
 import torch
 
 from .predictor_graph import PredictorGraph
-from .sampling import apply_repetition_penalty, sample_logits
+from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
 
 
@@ -45,11 +45,8 @@ def fast_generate_streaming(
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
 
-    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
-    suppress_start = max(0, vocab_size - 1024)
-    for i in range(suppress_start, vocab_size):
-        if i != eos_id:
-            suppress_mask[i] = True
+    suppress_mask = build_suppress_mask(vocab_size, eos_id, device)
+    eos_suppress_ids = torch.tensor([eos_id], dtype=torch.long, device=device)
 
     predictor = talker.code_predictor
     talker_codec_embed = talker.get_input_embeddings()
@@ -86,7 +83,7 @@ def fast_generate_streaming(
         top_p=top_p,
         do_sample=do_sample,
         suppress_mask=suppress_mask,
-        suppress_tokens=[eos_id] if suppress_eos else None,
+        suppress_tokens=eos_suppress_ids if suppress_eos else None,
     )
 
     prefill_len = talker_graph.prefill_kv(talker_past_kv)
@@ -148,7 +145,7 @@ def fast_generate_streaming(
             top_p=top_p,
             do_sample=do_sample,
             suppress_mask=suppress_mask,
-            suppress_tokens=[eos_id] if suppress_eos else None,
+            suppress_tokens=eos_suppress_ids if suppress_eos else None,
         )
         past_hidden = hidden_states[:, -1:, :].clone()
         gen_step += 1
@@ -218,11 +215,8 @@ def parity_generate_streaming(
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
 
-    suppress_mask = torch.zeros(vocab_size, dtype=torch.bool, device=device)
-    suppress_start = max(0, vocab_size - 1024)
-    for i in range(suppress_start, vocab_size):
-        if i != eos_id:
-            suppress_mask[i] = True
+    suppress_mask = build_suppress_mask(vocab_size, eos_id, device)
+    eos_suppress_ids = torch.tensor([eos_id], dtype=torch.long, device=device)
 
     # === PREFILL ===
     t_start = time.time()
@@ -253,7 +247,7 @@ def parity_generate_streaming(
         top_p=top_p,
         do_sample=do_sample,
         suppress_mask=suppress_mask,
-        suppress_tokens=[eos_id] if suppress_eos else None,
+        suppress_tokens=eos_suppress_ids if suppress_eos else None,
     )
 
     if attention_mask is not None:
@@ -319,7 +313,7 @@ def parity_generate_streaming(
             top_p=top_p,
             do_sample=do_sample,
             suppress_mask=suppress_mask,
-            suppress_tokens=[eos_id] if suppress_eos else None,
+            suppress_tokens=eos_suppress_ids if suppress_eos else None,
         )
 
         talker_past_kv = out.past_key_values


### PR DESCRIPTION
> **Stacked PR — first in the series** (base: `main`). Series order: this → #109 → #110 → rep-penalty history → fused codebook embeddings. Each PR's numbers are measured on top of the previous one; the last PR reports the cumulative gain vs `main`.

## What

Two per-request/per-step overhead removals in the sampling hot path:

1. **suppress_mask build**: was a Python loop issuing ~1024 individual indexed GPU writes on every `fast_generate` / `fast_generate_streaming` / `parity_generate_streaming` call. Now two slice ops (`mask[start:] = True; mask[eos] = False`), cached per `(vocab_size, eos_id, device)` in `sampling.build_suppress_mask`.
2. **EOS suppression during `min_new_tokens`**: `sample_logits` rebuilt a device tensor from the Python list `[eos_id]` every decode step (a small H2D copy per step). Callers now pass a precomputed index tensor; `sample_logits` accepts tensor `suppress_tokens` directly (iterables still work).

## Correctness

- `tests/test_e2e_parity.py::TestFP32Parity` + `TestBF16Parity`: **8 passed** (fp32 exact token parity incl. ICL prefix parity)
- `tests/test_sampling.py`: 2 passed
- bf16 seeded generation produces **bit-identical tokens** to main (first-codebook checksum 87308 on all runs, both branches)
- nano-parakeet transcription of generated audio: **WER 0.000** ("Ladies and gentlemen, I have just been informed that this speech is being generated faster than I can speak it. The robots have officially won. Please remain calm.")

## Performance (GB10, 0.6B-Base, ICL voice clone, 92-step utterance, 5 runs)

| metric | main | this PR |
|---|---|---|
| TTFA median (chunk_size=8) | 421.1 ms | **415.7 ms** |
| decode ms/step median | 35.86 | 35.91 (noise) |
| prefill ms median | 16.4 | 16.2 |

TTFA improves ~5 ms/call from removing the ~1024 launches; per-step cost is unchanged as expected (the per-step win here is one small H2D copy, which is hidden behind the GPU-bound step on this machine — it matters more on Jetson-class hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)