### PR TITLE
perf: remove per-step StaticCache reset in PredictorGraph.run

### DIFF
--- a/faster_qwen3_tts/predictor_graph.py
+++ b/faster_qwen3_tts/predictor_graph.py
@@ -209,6 +209,8 @@ class PredictorGraph:
         Returns: [15] long tensor of codebook tokens
         """
         self.input_buf.copy_(pred_input)
-        self.static_cache.reset()
+        # No cache reset needed between replays: each replay writes KV positions
+        # 0..max_seq-1 (prefill fills 0-1, the unrolled decode steps fill the rest)
+        # before any attention reads them, so stale values are never attended.
         self.graph.replay()
         return self.output_tokens.clone()


### PR DESCRIPTION
> **Stacked PR — based on #108** (`perf/vectorize-suppress-mask`). The series is ordered sequentially so each PR's numbers are measured on top of the previous one; the last PR in the stack reports the cumulative gain vs `main`.

## What

`PredictorGraph.run()` called `static_cache.reset()` before every graph replay — ~10 zero-fill kernel launches (5 layers × K/V) per generated talker token, in the hottest loop in the repo.

## Why it's safe

Every replay of the captured graph rewrites all attended KV positions before reading them: the 2-token prefill writes positions 0–1, the 14 unrolled decode steps write 2–15, and the precomputed attention masks never allow a query to attend beyond its own position. Stale values from the previous replay are therefore never observed. (Note `graph.replay()` re-executes only GPU kernels — Python-side cache state never advanced between replays anyway.) Resets during warmup/capture are kept.

## Correctness

- `TestFP32Parity` + `TestBF16Parity` + `test_sampling.py`: **10 passed** on the stacked branch
- bf16 seeded generation **bit-identical** to main (token checksum 87308, all runs)
- nano-parakeet transcript of generated audio: **WER 0.000**

## Performance (GB10, 0.6B-Base, ICL voice clone, 92-step utterance, 5 runs, measured on the stack)

| metric | #108 (base) | this PR |
|---|---|---|
| decode ms/step median | 35.91 | **35.68** |
| TTFA median (chunk_size=8) | 415.7 ms | **412.6 ms** |
| prefill ms median | 16.2 | 16.1 |

(For reference, `main` is 35.86 ms/step / 421.1 ms TTFA.) GB10 is GPU-bound per step so removed launches mostly hide behind compute; the win should be larger on launch-latency-bound hosts (Jetson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)