### PR TITLE
perf: deferred EOS check — remove the per-step GPU sync in decode loops

### DIFF
--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -11,6 +11,25 @@ from .predictor_graph import PredictorGraph
 from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
 
+_EOS_TRACKER_CACHE: dict = {}
+
+
+def get_eos_tracker(device) -> tuple:
+    """Pinned host buffer + events for deferred EOS detection.
+
+    Cached per device: pinned allocation costs several ms, which would land on
+    every call's TTFA. Generation is single-stream so sharing scratch is safe.
+    """
+    key = str(device)
+    tracker = _EOS_TRACKER_CACHE.get(key)
+    if tracker is None:
+        tracker = (
+            torch.zeros(2, dtype=torch.long, pin_memory=True),
+            (torch.cuda.Event(), torch.cuda.Event()),
+        )
+        _EOS_TRACKER_CACHE[key] = tracker
+    return tracker
+
 
 @torch.inference_mode()
 def fast_generate(
@@ -137,17 +156,43 @@ def fast_generate(
     rope_deltas = getattr(talker, "rope_deltas", None)
     talker_graph.set_generation_state(attention_mask, rope_deltas)
     
+    # Deferred EOS detection: token values are copied to a pinned host buffer
+    # asynchronously and checked one iteration late, so the CPU never blocks on
+    # the GPU mid-step (a per-step .item() would drain the launch queue every
+    # iteration). Slot k%2 holds the token consumed by iteration k. At the top
+    # of iteration k we first check iteration k-1's token (its copy was enqueued
+    # two iterations of GPU work ago and is almost always already complete),
+    # then opportunistically check token k itself if its copy already landed —
+    # the common case on hosts slower than the GPU, where this stops exactly at
+    # EOS. Otherwise EOS costs one extra (overshoot) iteration that is popped.
+    token_cpu, token_events = get_eos_tracker(device)
+    token_cpu[0:1].copy_(token, non_blocking=True)
+    token_events[0].record()
+
     torch.cuda.synchronize()
     t_prefill = time.time() - t_start
-    
+
     # === DECODE LOOP ===
     t_decode_start = time.time()
     all_codec_ids = []
-    
+    eos_found = False
+
     for step_idx in range(max_new_tokens):
-        if token.item() == eos_id:
+        if step_idx > 0:
+            prev_slot = (step_idx - 1) % 2
+            token_events[prev_slot].synchronize()
+            if int(token_cpu[prev_slot]) == eos_id:
+                # Previous iteration consumed EOS — drop its output and stop.
+                all_codec_ids.pop()
+                eos_found = True
+                break
+        cur_slot = step_idx % 2
+        if token_events[cur_slot].query() and int(token_cpu[cur_slot]) == eos_id:
+            # This iteration's own token is already visible and is EOS — stop
+            # before doing any work (no overshoot).
+            eos_found = True
             break
-        
+
         # --- CUDA-Graphed Code Predictor ---
         last_id_hidden = talker_codec_embed(token.unsqueeze(1))  # [1, 1, H]
         pred_input = torch.cat((past_hidden, last_id_hidden), dim=1)  # [1, 2, H]
@@ -193,12 +238,21 @@ def fast_generate(
             suppress_mask=suppress_mask,
             suppress_tokens=eos_suppress_ids if suppress_eos else None,
         )
+        next_slot = (step_idx + 1) % 2
+        token_cpu[next_slot:next_slot + 1].copy_(token, non_blocking=True)
+        token_events[next_slot].record()
         past_hidden = hidden_states[:, -1:, :].clone()  # clone since it's the static buffer
         gen_step += 1
-    
+
     torch.cuda.synchronize()
+    # The loop can exit (budget/seq-len) with the newest entry still unchecked;
+    # its token lives in slot (n-1)%2 since slots are keyed by iteration index.
+    if not eos_found and all_codec_ids:
+        last_slot = (len(all_codec_ids) - 1) % 2
+        if int(token_cpu[last_slot]) == eos_id:
+            all_codec_ids.pop()
     t_decode = time.time() - t_decode_start
-    
+
     n_steps = len(all_codec_ids)
     timing = {
         'prefill_ms': t_prefill * 1000,

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -10,6 +10,7 @@ from typing import Generator, Tuple
 
 import torch
 
+from .generate import get_eos_tracker
 from .predictor_graph import PredictorGraph
 from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
@@ -90,6 +91,15 @@ def fast_generate_streaming(
     rope_deltas = getattr(talker, "rope_deltas", None)
     talker_graph.set_generation_state(attention_mask, rope_deltas)
 
+    # Deferred EOS detection (see fast_generate): tokens are copied to a pinned
+    # host buffer asynchronously and checked one iteration late so the CPU never
+    # blocks on the GPU mid-step. Slot k%2 holds the token consumed by iteration
+    # k. Chunk flushes additionally validate their tail entry (after the sync
+    # they already perform) so an EOS overshoot is never yielded downstream.
+    token_cpu, token_events = get_eos_tracker(device)
+    token_cpu[0:1].copy_(token, non_blocking=True)
+    token_events[0].record()
+
     torch.cuda.synchronize()
     t_prefill = time.time() - t_start
 
@@ -98,10 +108,25 @@ def fast_generate_streaming(
     all_first_tokens = []  # for repetition penalty across chunks
     total_steps = 0
     chunk_count = 0
+    eos_found = False
     chunk_start = time.time()
 
     for step_idx in range(max_new_tokens):
-        if token.item() == eos_id:
+        if step_idx > 0:
+            prev_slot = (step_idx - 1) % 2
+            token_events[prev_slot].synchronize()
+            if int(token_cpu[prev_slot]) == eos_id:
+                # Previous iteration consumed EOS — drop its output and stop.
+                # The entry is always still in chunk_buffer: a flush validates
+                # its tail before yielding, so an EOS entry never leaves it.
+                chunk_buffer.pop()
+                eos_found = True
+                break
+        cur_slot = step_idx % 2
+        if token_events[cur_slot].query() and int(token_cpu[cur_slot]) == eos_id:
+            # This iteration's own token is already visible and is EOS — stop
+            # before doing any work (no overshoot).
+            eos_found = True
             break
 
         # --- CUDA-Graphed Code Predictor ---
@@ -147,12 +172,22 @@ def fast_generate_streaming(
             suppress_mask=suppress_mask,
             suppress_tokens=eos_suppress_ids if suppress_eos else None,
         )
+        next_slot = (step_idx + 1) % 2
+        token_cpu[next_slot:next_slot + 1].copy_(token, non_blocking=True)
+        token_events[next_slot].record()
         past_hidden = hidden_states[:, -1:, :].clone()
         gen_step += 1
 
         # --- Yield chunk when buffer is full ---
         if len(chunk_buffer) >= chunk_size:
             torch.cuda.synchronize()
+            # This chunk's tail entry hasn't been EOS-checked yet (that happens
+            # at the top of the next iteration); validate it now that we're synced.
+            if int(token_cpu[step_idx % 2]) == eos_id:
+                chunk_buffer.pop()
+                eos_found = True
+                if not chunk_buffer:
+                    break
             chunk_decode_time = time.time() - chunk_start
             total_steps += len(chunk_buffer)
 
@@ -162,16 +197,26 @@ def fast_generate_streaming(
                 'prefill_ms': t_prefill * 1000 if chunk_count == 0 else 0,
                 'decode_ms': chunk_decode_time * 1000,
                 'total_steps_so_far': total_steps,
-                'is_final': False,
+                'is_final': eos_found,
             }
 
             chunk_buffer = []
+            if eos_found:
+                break
             chunk_count += 1
             chunk_start = time.time()
 
     # --- Yield final partial chunk ---
     if chunk_buffer:
         torch.cuda.synchronize()
+        if not eos_found:
+            # Loop exited on budget/seq-len with the newest entry unchecked;
+            # slots are keyed by global iteration index.
+            tail_idx = total_steps + len(chunk_buffer) - 1
+            if int(token_cpu[tail_idx % 2]) == eos_id:
+                chunk_buffer.pop()
+
+    if chunk_buffer:
         chunk_decode_time = time.time() - chunk_start
         total_steps += len(chunk_buffer)
 


### PR DESCRIPTION
> **Stacked PR — based on #109** (`perf/remove-predictor-reset`). Series order: #108 → #109 → this → rep-penalty history → fused codebook embeddings. Each PR's numbers are measured on top of the previous one.

## What

Both `fast_generate` and `fast_generate_streaming` started every decode iteration with `if token.item() == eos_id`, a hard device sync that drains the launch queue: the GPU finishes the step, then sits idle while the CPU runs the Python glue and launches the next step. This PR replaces it with an asynchronous EOS check:

- Each sampled token is copied (`non_blocking=True`) into a **cached pinned host buffer** (2 slots + 2 CUDA events, slot = iteration index mod 2; a fresh pinned alloc costs ~9 ms on GB10, so it's cached per device).
- The top of iteration *k* blocks only on iteration *k−1*'s copy — enqueued two GPU iterations earlier and essentially always complete — so the CPU stays ~1 step ahead and keeps the GPU fed.
- Iteration *k*'s own token is also checked **non-blockingly** (`event.query()`): on hosts slower than the GPU (Jetson), the copy has already landed and generation stops exactly at EOS with zero wasted work.
- Otherwise EOS costs **one overshoot iteration** whose output is popped before returning. Streaming flushes validate their tail entry right after the sync they already perform, so an overshoot entry is **never yielded** to the consumer; `is_final` semantics are preserved (EOS exactly on a chunk boundary yields the same chunks as main).

`parity_generate_streaming` (the dynamic-cache reference path) intentionally keeps the simple `.item()` check.

## Correctness

- `TestFP32Parity` + `TestBF16Parity` + `test_sampling.py`: **10 passed** on the stacked branch (incl. streaming-matches-non-streaming prefix and the min_new_tokens + EOS-pop path)
- bf16 seeded generation **bit-identical** to main (token checksum 87308, all runs)
- nano-parakeet transcript: **WER 0.000**

## Performance (GB10, 0.6B-Base, ICL voice clone, 92-step utterance, 5 runs, measured on the stack)

| metric | #109 (base) | this PR |
|---|---|---|
| decode ms/step median | 35.68 | 35.99 |
| TTFA median (chunk_size=8) | 412.6 ms | 416.6 ms |

**GB10 is the wrong machine to judge this PR**: its Grace host is fast enough that decode is GPU-bound and the sync this removes was nearly free, so what's visible here is the small cost of the mechanism (~1 discarded overshoot step per utterance, i.e. +1/92 ≈ +0.4% in the ms/step accounting, plus event waits). The target is launch-bound hosts: a launch-bound microbench on this machine (chained matmuls + per-iteration token readback) shows `.item()` **19.9 ms/iter** → deferred pinned-copy+event **7.7 ms/iter**. On Jetson, where ~16 ms of a 54 ms step is CPU glue, this is the change that lets the CPU launch step *k+1* while the GPU still executes step *k*.

**Recommendation: benchmark on the Jetson before merging** — if it doesn't deliver there, drop this PR and rebase the rest of the stack; the changes after it apply cleanly without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)