### PR TITLE
perf: preallocated repetition-penalty history buffer

### DIFF
--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -176,6 +176,11 @@ def fast_generate(
     t_decode_start = time.time()
     all_codec_ids = []
     eos_found = False
+    # Preallocated first-codebook history for repetition penalty; rebuilding it
+    # with torch.stack over a growing list is O(n) launches per step.
+    rep_history = None
+    if repetition_penalty != 1.0:
+        rep_history = torch.empty(max_new_tokens, dtype=torch.long, device=device)
 
     for step_idx in range(max_new_tokens):
         if step_idx > 0:
@@ -197,11 +202,13 @@ def fast_generate(
         last_id_hidden = talker_codec_embed(token.unsqueeze(1))  # [1, 1, H]
         pred_input = torch.cat((past_hidden, last_id_hidden), dim=1)  # [1, 2, H]
         codebook_token_ids = predictor_graph.run(pred_input)  # [15] long tensor
-        
+
         # Build full codec: [first_cb, cb1, ..., cb15]
         all_cb = torch.cat([token.view(1), codebook_token_ids])  # [16]
         all_codec_ids.append(all_cb.detach())
-        
+        if rep_history is not None:
+            rep_history[step_idx:step_idx + 1] = token
+
         # --- Build input embedding for talker ---
         codec_hiddens = [last_id_hidden]
         for i in range(num_code_groups - 1):
@@ -224,9 +231,10 @@ def fast_generate(
         
         logits = talker_codec_head(hidden_states[:, -1, :]).unsqueeze(0)
         
-        if repetition_penalty != 1.0 and len(all_codec_ids) > 0:
-            history = torch.stack([c[0] for c in all_codec_ids])
-            logits = apply_repetition_penalty(logits, history, repetition_penalty)
+        if rep_history is not None:
+            logits = apply_repetition_penalty(
+                logits, rep_history[:step_idx + 1], repetition_penalty
+            )
 
         suppress_eos = len(all_codec_ids) < min_new_tokens
         token = sample_logits(

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -105,7 +105,11 @@ def fast_generate_streaming(
 
     # === DECODE LOOP — yield chunks ===
     chunk_buffer = []
-    all_first_tokens = []  # for repetition penalty across chunks
+    # Preallocated first-codebook history for repetition penalty across chunks;
+    # rebuilding it with torch.stack over a growing list is O(n) launches per step.
+    rep_history = None
+    if repetition_penalty != 1.0:
+        rep_history = torch.empty(max_new_tokens, dtype=torch.long, device=device)
     total_steps = 0
     chunk_count = 0
     eos_found = False
@@ -136,7 +140,8 @@ def fast_generate_streaming(
 
         all_cb = torch.cat([token.view(1), codebook_token_ids])
         chunk_buffer.append(all_cb.detach())
-        all_first_tokens.append(token.detach())
+        if rep_history is not None:
+            rep_history[step_idx:step_idx + 1] = token
 
         # --- Build input embedding for talker ---
         codec_hiddens = [last_id_hidden]
@@ -158,11 +163,12 @@ def fast_generate_streaming(
 
         logits = talker_codec_head(hidden_states[:, -1, :]).unsqueeze(0)
 
-        if repetition_penalty != 1.0 and all_first_tokens:
-            history = torch.stack(all_first_tokens)
-            logits = apply_repetition_penalty(logits, history, repetition_penalty)
+        if rep_history is not None:
+            logits = apply_repetition_penalty(
+                logits, rep_history[:step_idx + 1], repetition_penalty
+            )
 
-        suppress_eos = len(all_first_tokens) < min_new_tokens
+        suppress_eos = step_idx + 1 < min_new_tokens
         token = sample_logits(
             logits.squeeze(0),
             temperature=temperature,


### PR DESCRIPTION
> **Stacked PR — based on #110** (`perf/deferred-eos-check`). Series order: #108 → #109 → #110 → this → fused codebook embeddings. Each PR's numbers are measured on top of the previous one.

## What

Both fast decode loops rebuilt the repetition-penalty history every step with `torch.stack` over a growing Python list of GPU scalars — O(n) kernel launches per step, O(n²) over a generation (at step 200 that's 200 stacked single-element tensors, every step). Each consumed token is now written once into a preallocated `[max_new_tokens]` device buffer (a single async D2D scalar copy per step) and `apply_repetition_penalty` receives a slice view.

The streaming loop's `all_first_tokens` list existed only for this and for the `min_new_tokens` count, which is now derived from `step_idx`; the list is gone. `parity_generate_streaming` (dynamic-cache reference path) is unchanged.

## Correctness

- `TestFP32Parity` + `TestBF16Parity` + `test_sampling.py`: **10 passed** on the stacked branch
- bf16 seeded generation **bit-identical** to main (token checksum 87308, all runs)
- nano-parakeet transcript: **WER 0.000**

## Performance (GB10, 0.6B-Base, ICL voice clone, 92-step utterance, 5 runs, measured on the stack)

| metric | #110 (base) | this PR |
|---|---|---|
| decode ms/step median | 35.99 | **35.93** |
| TTFA median (chunk_size=8) | 416.6 ms | **411.9 ms** |

GB10 decode is GPU-bound so launch savings mostly hide behind compute; the structural win (constant per-step cost instead of O(n) launches) matters most for long generations and launch-bound hosts, and is also a prerequisite for ever folding the penalty into a captured graph (static shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)