### PR TITLE
perf: fuse the 15 predictor codebook embedding lookups into one gather

### DIFF
--- a/faster_qwen3_tts/generate.py
+++ b/faster_qwen3_tts/generate.py
@@ -6,6 +6,7 @@ import time
 from typing import Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 
 from .predictor_graph import PredictorGraph
 from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
@@ -29,6 +30,28 @@ def get_eos_tracker(device) -> tuple:
         )
         _EOS_TRACKER_CACHE[key] = tracker
     return tracker
+
+
+def get_fused_codec_embeddings(predictor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return (weights, offsets) for a single fused lookup over the predictor's
+    15 per-codebook embedding tables.
+
+    The decode loop needs one embedding row from each of the 15 tables every
+    step; looking them up table-by-table costs 15 kernel launches plus a cat.
+    Concatenating the tables once lets a single F.embedding gather all 15 rows:
+    row i of codebook cb lives at offsets[cb] + i. Cached on the predictor
+    module (costs one duplicated copy of the tables in VRAM).
+    """
+    cached = getattr(predictor, "_fqt_fused_codec_embed", None)
+    if cached is None:
+        embeds = list(predictor.get_input_embeddings())
+        weights = torch.cat([e.weight for e in embeds], dim=0)
+        sizes = torch.tensor([e.weight.shape[0] for e in embeds])
+        offsets = torch.zeros(len(embeds), dtype=torch.long, device=weights.device)
+        offsets[1:] = sizes[:-1].cumsum(0).to(weights.device)
+        cached = (weights, offsets)
+        predictor._fqt_fused_codec_embed = cached
+    return cached
 
 
 @torch.inference_mode()
@@ -58,7 +81,6 @@ def fast_generate(
     Fast autoregressive generation with CUDA-graphed predictor and talker.
     """
     eos_id = config.codec_eos_token_id
-    num_code_groups = config.num_code_groups
     vocab_size = config.vocab_size
     device = talker_input_embeds.device
     
@@ -116,8 +138,8 @@ def fast_generate(
     predictor = talker.code_predictor
     talker_codec_embed = talker.get_input_embeddings()
     talker_codec_head = talker.codec_head
-    predictor_codec_embeds = predictor.get_input_embeddings()
-    
+    fused_codec_weights, fused_codec_offsets = get_fused_codec_embeddings(predictor)
+
     # === PREFILL (still uses HF forward for variable-length prefill) ===
     t_start = time.time()
     
@@ -210,11 +232,13 @@ def fast_generate(
             rep_history[step_idx:step_idx + 1] = token
 
         # --- Build input embedding for talker ---
-        codec_hiddens = [last_id_hidden]
-        for i in range(num_code_groups - 1):
-            codec_hiddens.append(predictor_codec_embeds[i](codebook_token_ids[i].unsqueeze(0).unsqueeze(0)))
-        inputs_embeds = torch.cat(codec_hiddens, dim=1).sum(1, keepdim=True)
-        
+        # One fused gather over all 15 codebook tables; the cat+sum keeps the
+        # exact reduction order of the previous per-table loop for parity.
+        codebook_embeds = F.embedding(
+            codebook_token_ids + fused_codec_offsets, fused_codec_weights
+        ).unsqueeze(0)  # [1, 15, H]
+        inputs_embeds = torch.cat((last_id_hidden, codebook_embeds), dim=1).sum(1, keepdim=True)
+
         if gen_step < trailing_text_hiddens.shape[1]:
             inputs_embeds = inputs_embeds + trailing_text_hiddens[:, gen_step].unsqueeze(1)
         else:

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -9,8 +9,9 @@ import time
 from typing import Generator, Tuple
 
 import torch
+import torch.nn.functional as F
 
-from .generate import get_eos_tracker
+from .generate import get_eos_tracker, get_fused_codec_embeddings
 from .predictor_graph import PredictorGraph
 from .sampling import apply_repetition_penalty, build_suppress_mask, sample_logits
 from .talker_graph import TalkerGraph
@@ -52,8 +53,7 @@ def fast_generate_streaming(
     predictor = talker.code_predictor
     talker_codec_embed = talker.get_input_embeddings()
     talker_codec_head = talker.codec_head
-    predictor_codec_embeds = predictor.get_input_embeddings()
-    num_code_groups = config.num_code_groups
+    fused_codec_weights, fused_codec_offsets = get_fused_codec_embeddings(predictor)
 
     # === PREFILL (still uses HF forward for variable-length prefill) ===
     t_start = time.time()
@@ -144,10 +144,12 @@ def fast_generate_streaming(
             rep_history[step_idx:step_idx + 1] = token
 
         # --- Build input embedding for talker ---
-        codec_hiddens = [last_id_hidden]
-        for i in range(num_code_groups - 1):
-            codec_hiddens.append(predictor_codec_embeds[i](codebook_token_ids[i].unsqueeze(0).unsqueeze(0)))
-        inputs_embeds = torch.cat(codec_hiddens, dim=1).sum(1, keepdim=True)
+        # One fused gather over all 15 codebook tables; the cat+sum keeps the
+        # exact reduction order of the previous per-table loop for parity.
+        codebook_embeds = F.embedding(
+            codebook_token_ids + fused_codec_offsets, fused_codec_weights
+        ).unsqueeze(0)  # [1, 15, H]
+        inputs_embeds = torch.cat((last_id_hidden, codebook_embeds), dim=1).sum(1, keepdim=True)
 
         if gen_step < trailing_text_hiddens.shape[1]:
             inputs_embeds = inputs_embeds + trailing_text_hiddens[:, gen_step].unsqueeze(1)


### PR DESCRIPTION
> **Stacked PR — last in the series**: #108 → #109 → #110 → #111 → this. Based on `perf/static-rep-penalty-history`.

## What

Building the talker input embedding looked up one row from each of the predictor's 15 per-codebook embedding tables in a Python loop — 15 separate gather launches plus a `cat` per decode step. The tables are now concatenated once into a single `[Σvocab, H]` tensor (cached on the predictor module via `get_fused_codec_embeddings`; costs one duplicated copy of the tables in VRAM) and all 15 rows are fetched with a single `F.embedding(codebook_token_ids + offsets, fused)`.

The `cat(last_id_hidden, …).sum(1)` reduction shape is kept identical to the previous per-table code path, so outputs stay **bit-exact** — confirmed by the unchanged token checksum below.

## Correctness

- `TestFP32Parity` + `TestBF16Parity` + `test_sampling.py`: **10 passed** on the stacked branch
- bf16 seeded generation **bit-identical** to main (token checksum 87308, all runs)
- nano-parakeet transcript: **WER 0.000** ("Ladies and gentlemen, I have just been informed that this speech is being generated faster than I can speak it. The robots have officially won. Please remain calm.")

## Performance (GB10, 0.6B-Base, ICL voice clone, 92-step utterance, 5 runs)

| metric | #111 (base) | this PR |
|---|---|---|
| decode ms/step median | 35.93 | **35.84** |
| TTFA median (chunk_size=8) | 411.9 ms | 414.4 ms |

## Cumulative — full stack vs `main` (same protocol, same machine)

| stack level | ms/step | TTFA (cs=8) | prefill | tokens | WER |
|---|---|---|---|---|---|
| `main` | 35.86 | 421.1 ms | 16.4 ms | 87308 | 0.000 |
| + #108 suppress-mask vectorization | 35.91 | 415.7 ms | 16.2 ms | 87308 | 0.000 |
| + #109 predictor reset removal | 35.68 | 412.6 ms | 16.1 ms | 87308 | 0.000 |
| + #110 deferred EOS check | 35.99 | 416.6 ms | 16.4 ms | 87308 | 0.000 |
| + #111 rep-penalty buffer | 35.93 | 411.9 ms | 16.2 ms | 87308 | 0.000 |
| + this PR (fused embeddings) | **35.84** | **414.4 ms** | 16.1 ms | 87308 | 0.000 |

Honest read of the cumulative numbers: on **GB10** (fast Grace host; decode is GPU-bound at ~35.8 ms/step) the stack is **throughput-neutral and ~7 ms better on TTFA**, with outputs bit-identical at every level. That's expected — every change in this stack removes *CPU-side launch overhead and syncs*, which GB10 hides behind GPU compute. The hardware these PRs target is the **Jetson-class deployment** (≈16 ms of CPU glue per 54 ms step per the README breakdown), where per-step kernel-launch count and the removed per-step sync are the bottleneck. The stack removes per step: ~10 zero-fill launches (#109), the O(n) history rebuild (#111), 14 gather launches + a cat (this PR), and the hard CPU↔GPU round-trip (#110). A Jetson run of `benchmarks/throughput.py` on this branch vs `main` would quantify the end-to-end win there before merging the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)