### PR TITLE
docs: document Tesla T4 / CUDA-12.4-driver setup + add T4 benchmark rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ pip install faster-qwen3-tts
 
 **Blackwell note:** RTX 50xx / Blackwell GPUs need CUDA 12.8 PyTorch wheels. If the default setup fails on those cards, install a `cu128` PyTorch build (PyTorch 2.7+).
 
+**Driver / CUDA mismatch note (T4, A10G, and other CUDA-12.4 hosts):** `pip install` pulls the default PyTorch wheel, which is built against a recent CUDA toolkit. If your NVIDIA driver is *older* than that toolkit — common on CUDA 12.4 hosts such as AWS, Azure ML, and many Colab/T4 boxes — `torch.cuda.is_available()` returns `False` with `CUDA initialization: The NVIDIA driver on your system is too old`. Install a PyTorch wheel matching your driver's CUDA version. Check it with `nvidia-smi` (top-right "CUDA Version"); for a CUDA 12.4 driver:
+
+```bash
+pip install "torch==2.5.1" "torchaudio==2.5.1" --index-url https://download.pytorch.org/whl/cu124
+```
+
 ## Quick Start
 
 ### Python
@@ -163,6 +169,7 @@ Benchmarks include tokenization + inference (apples-to-apples with baseline). RT
 | RTX 4090 | 0.82 | 800ms | **4.78** | **156ms** | 5.8x / 5.1x |
 | RTX 4060 (Windows) | 0.23 | 2,697ms | **2.26** | **413ms** | 9.8x / 6.5x |
 | H100 80GB HBM3 | 0.435 | 1,474ms | **3.884** | **228ms** | 8.9x / 6.5x |
+| Tesla T4 16GB | 0.467 | 1,671ms | **1.068** | **901ms** | 2.3x / 1.9x |
 
 ### 1.7B Model
 
@@ -173,6 +180,7 @@ Benchmarks include tokenization + inference (apples-to-apples with baseline). RT
 | RTX 4090 | 0.82 | 850ms | **4.22** | **174ms** | 5.1x / 4.9x |
 | RTX 4060 (Windows) | 0.23 | 2,905ms | **1.83** | **460ms** | 7.9x / 6.3x |
 | H100 80GB HBM3 | 0.439 | 1,525ms | **3.304** | **241ms** | 7.5x / 6.3x |
+| Tesla T4 16GB | 0.453 | 1,811ms | **0.925** | **1,096ms** | 2.0x / 1.7x |
 
 **Note:** Baseline TTFA values are **streaming TTFA** from the community `Qwen3-TTS-streaming` fork (which adds streaming) or from our **dynamic-cache parity streaming** path (no CUDA graphs) where available. The official `Qwen3-TTS` repo does **not** currently support streaming, so without a streaming baseline TTFA would be **time-to-full-audio**. CUDA graphs uses `generate_voice_clone_streaming(chunk_size=8)` for TTFA. Both include text tokenization for fair comparison. Speedup shows throughput / TTFA improvement. The streaming fork reports additional speedups that appear tied to `torch.compile`; we couldn’t reproduce those on Jetson-class devices where `torch.compile` isn’t available.
 

--- a/setup.sh
+++ b/setup.sh
@@ -30,9 +30,16 @@ fi
 # Verify CUDA
 .venv/bin/python -c "import torch; assert torch.cuda.is_available(), 'CUDA not available'; print(f'PyTorch {torch.__version__}, CUDA {torch.version.cuda}, GPU: {torch.cuda.get_device_name(0)}')" || {
     echo ""
-    echo "WARNING: CUDA not available. You may need to install a CUDA-enabled PyTorch wheel."
-    echo "  uv pip install torch --index-url https://download.pytorch.org/whl/cu128 --python .venv/bin/python"
-    echo "  Note: RTX 50xx / Blackwell GPUs need CUDA 12.8 wheels (PyTorch 2.7+)."
+    echo "WARNING: CUDA not available — usually a driver/toolkit mismatch."
+    echo "  The default 'pip install' pulls the latest PyTorch wheel, built against a recent CUDA"
+    echo "  toolkit. If your NVIDIA driver is older than that toolkit you'll see"
+    echo "  'CUDA initialization: The NVIDIA driver on your system is too old'."
+    echo "  Check your driver's max CUDA version with: nvidia-smi  (top-right 'CUDA Version')."
+    echo "  Then install a matching PyTorch wheel, e.g.:"
+    echo "    - Driver CUDA 12.4 (e.g. T4 / A10G / many cloud & Colab GPUs):"
+    echo "        uv pip install torch==2.5.1 torchaudio==2.5.1 --index-url https://download.pytorch.org/whl/cu124 --python .venv/bin/python"
+    echo "    - Driver CUDA 12.8+ (RTX 50xx / Blackwell):"
+    echo "        uv pip install torch --index-url https://download.pytorch.org/whl/cu128 --python .venv/bin/python"
 }
 
 # Pre-download models to HuggingFace cache


### PR DESCRIPTION
## Problem

On a fresh setup, `./setup.sh` (and `pip install faster-qwen3-tts`) installs the **latest** PyTorch wheel, because `pyproject.toml` pins `torch>=2.5.1` with no upper bound. The latest wheel is built against a recent CUDA toolkit, so on hosts whose **NVIDIA driver is older than that toolkit** — very common **CUDA 12.4** boxes (AWS, Azure ML, many Colab/T4 instances) — CUDA fails to initialize and `benchmark.sh` aborts:

```
.../torch/cuda/__init__.py:187: UserWarning: CUDA initialization: The NVIDIA driver on your
system is too old (found version 12040). ...
AssertionError: CUDA not available

=== benchmark.sh both ===
ERROR: PyTorch with CUDA required. Check your venv.
```

Here `pip` had resolved `torch==2.12.0`; the box driver is `550.163.01` (= CUDA 12.4). The existing `setup.sh` hint only points at `cu128` (a **newer** toolkit), which makes the *driver-too-old* case worse rather than better.

## Fix

- **README** — add a "Driver / CUDA mismatch" note beside the Blackwell note, with the matching-wheel command for CUDA 12.4 drivers.
- **setup.sh** — the "CUDA not available" hint now explains the mismatch and offers **both** the `cu124` (12.4 driver: T4 / A10G / many cloud & Colab GPUs) and `cu128` (Blackwell) wheel commands.
- **README results** — add measured **Tesla T4 16GB** rows to the 0.6B and 1.7B tables (no Turing-class datacenter GPU was listed).

No dependency pin is changed — this is documentation + a corrected setup hint, so users on newer drivers keep getting newer torch.

## Verification (Tesla T4 16GB)

With the matching wheel the fast path works end-to-end:

```
$ pip install "torch==2.5.1" "torchaudio==2.5.1" --index-url https://download.pytorch.org/whl/cu124
$ python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available(), torch.cuda.get_device_name(0))"
2.5.1+cu124 12.4 True Tesla T4
$ ./benchmark.sh both
```

Measured with the repo's own `./benchmark.sh both` (chunk_size=8):

| Model | Baseline RTF | CUDA Graphs RTF | Baseline TTFA | CUDA Graphs TTFA | Speedup |
|---|---|---|---|---|---|
| 0.6B | 0.467 | **1.068** | 1,671 ms | **901 ms** | 2.3x / 1.9x |
| 1.7B | 0.453 | **0.925** | 1,811 ms | **1,096 ms** | 2.0x / 1.7x |

CUDA graph capture works on Turing (sm_75); the 0.6B model clears real-time (RTF > 1). Peak VRAM **6.7 GB** (fits the T4's 16 GB with headroom). Sample outputs: `sample_0.6B.wav` 8.64 s, `sample_1.7B.wav` 6.48 s.

![Tesla T4 — CUDA graphs vs baseline](https://raw.githubusercontent.com/moduvoice/faster-qwen3-tts/t4-bench-assets/t4_benchmark.png)

**Environment:** Tesla T4 16GB · driver 550.163.01 (CUDA 12.4) · Python 3.10 · torch 2.5.1+cu124 · measured with `./benchmark.sh both`.

<details><summary>Raw <code>bench_results_Tesla_T4.json</code> (key fields)</summary>

```json
{
  "0.6B": {"gpu": "Tesla_T4", "streaming_baseline_rtf": 0.4668, "streaming_fast_rtf": 1.0683,
            "streaming_baseline_ttfa_ms": 1671.3, "streaming_fast_ttfa_ms": 901.3},
  "1.7B": {"gpu": "Tesla_T4", "streaming_baseline_rtf": 0.4529, "streaming_fast_rtf": 0.9252,
            "streaming_baseline_ttfa_ms": 1811.3, "streaming_fast_ttfa_ms": 1096.3}
}
```
</details>
