### PR TITLE
Add GGML backend integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ sample_*.wav
 __pycache__/
 *.pyc
 .venv/
+.cache/
+outputs/
+artifacts/
+packages/qwentts_cpp_python/

--- a/README.md
+++ b/README.md
@@ -38,12 +38,19 @@ faster-qwen3-tts --backend ggml --quant BF16 design \
 ```
 
 The extra installs `qwentts-cpp-python>=0.3.0` from PyPI. That default wheel is
-CUDA 12.8. For CUDA 13 / DGX Spark or CUDA 12.4 targets, install the matching
-wrapper wheel from the Hugging Face wheelhouse before installing the extra:
+CUDA 12.8. For CUDA 13 / DGX Spark, CUDA 12.4 targets, or Ubuntu 22.04 / older
+Linux hosts that need a `manylinux_2_35` wheel, install the matching wrapper
+wheel from the Hugging Face wheelhouse before installing the extra:
 
 ```bash
+# Ubuntu 22.04 / older Linux with CUDA 12.8
+pip install "qwentts-cpp-python==0.3.0+cu128" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
+
+# CUDA 13 / DGX Spark
 pip install "qwentts-cpp-python==0.3.0+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
+
 pip install "faster-qwen3-tts[ggml]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,21 +37,22 @@ faster-qwen3-tts --backend ggml --quant BF16 design \
   --output out.wav
 ```
 
-The extra installs `qwentts-cpp-python>=0.2.0` from PyPI. That default wheel is
+The extra installs `qwentts-cpp-python>=0.3.0` from PyPI. That default wheel is
 CUDA 12.8. For CUDA 13 / DGX Spark or CUDA 12.4 targets, install the matching
 wrapper wheel from the Hugging Face wheelhouse before installing the extra:
 
 ```bash
-pip install "qwentts-cpp-python==0.2.0+cu130" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu130.html
+pip install "qwentts-cpp-python==0.3.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 pip install "faster-qwen3-tts[ggml]"
 ```
 
 See [`docs/ggml-backend.md`](docs/ggml-backend.md) for the native wrapper
 package and wheel selection details.
 
-Cached qwentts.cpp voice-clone references are supported when you already have
-`.spk` speaker latents, and optional `.rvq` acoustic latents for ICL:
+The GGML backend caches raw reference audio as qwentts.cpp `.spk` speaker
+latents plus `.rvq` acoustic latents after the first clone request. You can also
+pass precomputed references directly:
 
 ```bash
 faster-qwen3-tts --backend ggml --quant BF16 clone \

--- a/README.md
+++ b/README.md
@@ -170,15 +170,17 @@ faster-qwen3-tts serve \
 
 ### Demo UI
 
-A minimal web UI that streams audio in real time and shows TTFA and RTF live:
+A minimal web UI that streams audio in real time and shows TTFA and RTF live.
+It defaults to GGML/qwentts.cpp and includes a backend toggle for comparing it
+against the Torch CUDA-graph backend:
 
 ```bash
-pip install -e ".[demo]"
-python demo/server.py
+pip install -e ".[demo,ggml]"
+python demo/server.py --backend ggml
 # open http://localhost:7860
 ```
 
-Features: voice clone (upload any WAV or use your microphone), voice design (1.7B-VoiceDesign model), streaming/non-streaming toggle, adjustable chunk size, live TTFA/RTF metrics, WAV download.
+Features: voice clone (upload any WAV or use your microphone), voice design (1.7B-VoiceDesign model), GGML/Torch backend toggle, streaming/non-streaming toggle, adjustable chunk size, live TTFA/RTF metrics, WAV download.
 
 ### OpenAI-compatible API server
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The original Qwen3TTS implementation supports two mode of generation. It either 
 The public API uses `non_streaming_mode=None` as a sentinel, which preserves each method's upstream default unless you override it explicitly.
 `generate_voice_clone` and `generate_voice_clone_streaming` resolve `None` to `False`, matching upstream step-by-step text feeding during decode.
 `generate_custom_voice`, `generate_custom_voice_streaming`, `generate_voice_design`, and `generate_voice_design_streaming` resolve `None` to `True`, matching the upstream CustomVoice and VoiceDesign defaults.
+The GGML backend currently has no qwentts.cpp ABI switch for step-by-step text feeding; passing `non_streaming_mode=False` emits a warning and qwentts.cpp uses its native prompt layout.
 
 **Performance impact (RTX 4090, 1.7B, ICL, chunk_size=8):** TTFA is unchanged (≈159ms ± 1ms), and RTF is effectively the same (nsm=False: 4.87 ± 0.01, nsm=True: 4.85 ± 0.01).
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,40 @@ pip install faster-qwen3-tts
 pip install "torch==2.5.1" "torchaudio==2.5.1" --index-url https://download.pytorch.org/whl/cu124
 ```
 
+### Experimental GGML backend
+
+There is an experimental adapter for Pascal's `qwentts.cpp` runtime. The
+current Torch/CUDA-graph backend remains the default; GGML is opt-in and
+uses a separate native wheel package so the main install path stays simple.
+
+```bash
+pip install "faster-qwen3-tts[ggml]"
+
+faster-qwen3-tts --backend ggml --quant BF16 design \
+  --model Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+  --instruct "Warm, confident narrator" \
+  --text "Welcome to the show." \
+  --language English \
+  --output out.wav
+```
+
+See [`docs/ggml-backend.md`](docs/ggml-backend.md) for the native wrapper
+package and wheel build details.
+
+Cached qwentts.cpp voice-clone references are supported when you already have
+`.spk` speaker latents, and optional `.rvq` acoustic latents for ICL:
+
+```bash
+faster-qwen3-tts --backend ggml --quant BF16 clone \
+  --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+  --ref-spk freeman.spk \
+  --ref-rvq freeman.rvq \
+  --ref-text "$(cat freeman.txt)" \
+  --text "Cached references skip reference audio encoding on every request." \
+  --language English \
+  --output out.wav
+```
+
 ## Quick Start
 
 ### Python

--- a/README.md
+++ b/README.md
@@ -37,8 +37,18 @@ faster-qwen3-tts --backend ggml --quant BF16 design \
   --output out.wav
 ```
 
+The extra installs `qwentts-cpp-python>=0.2.0` from PyPI. That default wheel is
+CUDA 12.8. For CUDA 13 / DGX Spark or CUDA 12.4 targets, install the matching
+wrapper wheel from the Hugging Face wheelhouse before installing the extra:
+
+```bash
+pip install "qwentts-cpp-python==0.2.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu130.html
+pip install "faster-qwen3-tts[ggml]"
+```
+
 See [`docs/ggml-backend.md`](docs/ggml-backend.md) for the native wrapper
-package and wheel build details.
+package and wheel selection details.
 
 Cached qwentts.cpp voice-clone references are supported when you already have
 `.spk` speaker latents, and optional `.rvq` acoustic latents for ICL:

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Benchmark Qwen3-TTS with CUDA Graphs
-# Usage: ./benchmark.sh [0.6B|1.7B|both|custom]
+# Benchmark Qwen3-TTS with CUDA Graphs.
+# Usage: ./benchmark.sh [0.6B|1.7B|both|custom|backends|backend-base]
 set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -40,6 +40,30 @@ run_custom() {
     echo ""
 }
 
+run_backend_compare() {
+    local size="${1:-1.7B}"
+    local mode="${2:-custom}"
+    local args=(
+        --backend both
+        --mode "$mode"
+        --model-size "$size"
+        --quant "${QUANT:-BF16}"
+        --greedy
+    )
+
+    if [ "${LOCAL_FILES_ONLY:-1}" != "0" ]; then
+        args+=(--local-files-only)
+    fi
+
+    if [ -n "${QWENTTS_LIB:-}" ]; then
+        args+=(--qwentts-lib "$QWENTTS_LIB")
+    fi
+
+    echo "--- Comparing Torch and GGML ($size, $mode) ---"
+    "$PY" "$DIR/benchmarks/backend_compare.py" "${args[@]}"
+    echo ""
+}
+
 case "$MODEL" in
     0.6B) run_model "0.6B" ;;
     1.7B) run_model "1.7B" ;;
@@ -51,8 +75,19 @@ case "$MODEL" in
         run_model "0.6B"
         run_model "1.7B"
         ;;
+    backends)
+        run_backend_compare "${MODEL_SIZE:-1.7B}" "${MODE:-custom}"
+        ;;
+    backend-base)
+        run_backend_compare "${MODEL_SIZE:-0.6B}" "base"
+        ;;
     *)
-        echo "Usage: ./benchmark.sh [0.6B|1.7B|both|custom]"
+        echo "Usage: ./benchmark.sh [0.6B|1.7B|both|custom|backends|backend-base]"
+        echo ""
+        echo "Backend comparison options:"
+        echo "  MODEL_SIZE=1.7B MODE=custom QUANT=BF16 ./benchmark.sh backends"
+        echo "  MODEL_SIZE=0.6B QUANT=BF16 ./benchmark.sh backend-base"
+        echo "  QWENTTS_LIB=/path/to/libqwen.so ./benchmark.sh backends"
         exit 1
         ;;
 esac

--- a/benchmarks/backend_compare.py
+++ b/benchmarks/backend_compare.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Compare faster-qwen3-tts torch and GGML backends on a shared workload."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from faster_qwen3_tts import FasterQwen3TTS
+
+
+DEFAULT_TEXT = (
+    "Ladies and gentlemen, I have just been informed that this speech is being "
+    "generated faster than I can speak it. Please remain calm."
+)
+DEFAULT_REF_TEXT = (
+    "I'm confused why some people have super short timelines, yet at the same "
+    "time are bullish on scaling up reinforcement learning atop LLMs. If we're "
+    "actually close to a human-like learner, then this whole approach of training "
+    "on verifiable outcomes is doomed."
+)
+
+
+def parse_chunk_sizes(value: str) -> list[int]:
+    sizes = [int(part.strip()) for part in value.split(",") if part.strip()]
+    if not sizes:
+        raise argparse.ArgumentTypeError("expected at least one chunk size")
+    if any(size <= 0 for size in sizes):
+        raise argparse.ArgumentTypeError("chunk sizes must be positive")
+    return sizes
+
+
+def sync_cuda() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+def model_id(size: str, mode: str) -> str:
+    suffix = "CustomVoice" if mode == "custom" else "Base"
+    return f"Qwen/Qwen3-TTS-12Hz-{size}-{suffix}"
+
+
+def local_snapshot_for(model: str) -> str:
+    hub_root = Path.home() / ".cache" / "huggingface" / "hub"
+    repo = "models--" + model.replace("/", "--")
+    snapshots = hub_root / repo / "snapshots"
+    if not snapshots.is_dir():
+        return model
+    dirs = sorted(path for path in snapshots.iterdir() if path.is_dir())
+    return str(dirs[-1]) if dirs else model
+
+
+def summarize_audio(audio: np.ndarray, sr: int, total_s: float) -> dict[str, Any]:
+    audio_s = len(audio) / sr if sr else 0.0
+    frames = max(1, int(round(audio_s * 12.5)))
+    return {
+        "audio_s": audio_s,
+        "total_s": total_s,
+        "frames": frames,
+        "ms_per_frame": total_s * 1000 / frames,
+        "compute_per_audio": total_s / audio_s if audio_s > 0 else None,
+        "audio_per_compute": audio_s / total_s if total_s > 0 else None,
+    }
+
+
+def load_model(args: argparse.Namespace, backend: str, model_name: str):
+    if backend == "ggml":
+        return FasterQwen3TTS.from_pretrained(
+            model_name,
+            backend="ggml",
+            quant=args.quant,
+            cache_dir=args.ggml_cache_dir,
+            local_files_only=args.local_files_only,
+            qwentts_library_path=args.qwentts_lib,
+        )
+
+    torch_model = local_snapshot_for(model_name) if args.local_files_only else model_name
+    return FasterQwen3TTS.from_pretrained(
+        torch_model,
+        device=args.device,
+        dtype=torch.bfloat16,
+        attn_implementation=args.attn_implementation,
+        max_seq_len=args.max_seq_len,
+    )
+
+
+def generation_kwargs(args: argparse.Namespace, mode: str) -> dict[str, Any]:
+    common = {
+        "text": args.text,
+        "language": args.language,
+        "max_new_tokens": args.max_new_tokens,
+        "do_sample": not args.greedy,
+        "temperature": args.temperature,
+        "top_k": args.top_k,
+        "top_p": args.top_p,
+        "repetition_penalty": args.repetition_penalty,
+    }
+    if mode == "custom":
+        return {
+            **common,
+            "speaker": args.speaker,
+            "instruct": args.instruct or None,
+        }
+    return {
+        **common,
+        "ref_audio": args.ref_audio,
+        "ref_text": args.ref_text,
+        "xvec_only": args.xvec_only,
+    }
+
+
+def generate_buffered(model, mode: str, kwargs: dict[str, Any]):
+    if mode == "custom":
+        return model.generate_custom_voice(**kwargs)
+    return model.generate_voice_clone(**kwargs)
+
+
+def generate_streaming(model, mode: str, kwargs: dict[str, Any], chunk_size: int):
+    stream_kwargs = {**kwargs, "chunk_size": chunk_size}
+    if mode == "custom":
+        return model.generate_custom_voice_streaming(**stream_kwargs)
+    return model.generate_voice_clone_streaming(**stream_kwargs)
+
+
+def run_backend(args: argparse.Namespace, backend: str) -> dict[str, Any]:
+    name = model_id(args.model_size, args.mode)
+    print(f"\n=== {backend} {args.model_size} {args.mode} {args.quant} ===", flush=True)
+    print(f"model: {name}", flush=True)
+
+    load_start = time.perf_counter()
+    model = load_model(args, backend, name)
+    sync_cuda()
+    load_s = time.perf_counter() - load_start
+    print(f"load: {load_s:.3f}s", flush=True)
+
+    kwargs = generation_kwargs(args, args.mode)
+    print("warmup...", flush=True)
+    warmup_kwargs = {**kwargs, "text": kwargs["text"][:50], "max_new_tokens": min(args.max_new_tokens, 20)}
+    warm_start = time.perf_counter()
+    generate_buffered(model, args.mode, warmup_kwargs)
+    sync_cuda()
+    warmup_s = time.perf_counter() - warm_start
+    print(f"warmup: {warmup_s:.3f}s", flush=True)
+
+    result: dict[str, Any] = {
+        "backend": backend,
+        "model": name,
+        "mode": args.mode,
+        "quant": args.quant,
+        "load_s": load_s,
+        "warmup_s": warmup_s,
+        "max_new_tokens": args.max_new_tokens,
+        "ttfa": {},
+        "buffered": [],
+        "streaming_chunk8": [],
+    }
+
+    print("TTFA sweep...", flush=True)
+    for chunk_size in args.chunk_sizes:
+        values = []
+        for run in range(args.ttfa_runs):
+            sync_cuda()
+            t0 = time.perf_counter()
+            stream = generate_streaming(model, args.mode, kwargs, chunk_size)
+            try:
+                chunk, sr, _timing = next(stream)
+            finally:
+                stream.close()
+            sync_cuda()
+            ttfa_ms = (time.perf_counter() - t0) * 1000
+            values.append(ttfa_ms)
+            print(
+                f"  chunk={chunk_size:2d} run={run + 1}: "
+                f"{ttfa_ms:.1f}ms, samples={len(chunk)}",
+                flush=True,
+            )
+        result["ttfa"][str(chunk_size)] = {
+            "mean_ms": float(np.mean(values)),
+            "std_ms": float(np.std(values)),
+            "runs_ms": values,
+        }
+
+    print("buffered throughput...", flush=True)
+    for run in range(args.throughput_runs):
+        sync_cuda()
+        t0 = time.perf_counter()
+        audio_list, sr = generate_buffered(model, args.mode, kwargs)
+        sync_cuda()
+        item = summarize_audio(audio_list[0], sr, time.perf_counter() - t0)
+        result["buffered"].append(item)
+        print(
+            f"  run={run + 1}: audio={item['audio_s']:.2f}s "
+            f"time={item['total_s']:.2f}s ms/frame={item['ms_per_frame']:.1f}",
+            flush=True,
+        )
+
+    print("streaming throughput (chunk=8)...", flush=True)
+    for run in range(args.throughput_runs):
+        chunks = []
+        sr = None
+        sync_cuda()
+        t0 = time.perf_counter()
+        for audio_chunk, sr, _timing in generate_streaming(model, args.mode, kwargs, 8):
+            chunks.append(audio_chunk)
+        sync_cuda()
+        audio = np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.float32)
+        item = summarize_audio(audio, sr or 24000, time.perf_counter() - t0)
+        item["chunks"] = len(chunks)
+        result["streaming_chunk8"].append(item)
+        print(
+            f"  run={run + 1}: chunks={len(chunks)} audio={item['audio_s']:.2f}s "
+            f"time={item['total_s']:.2f}s ms/frame={item['ms_per_frame']:.1f}",
+            flush=True,
+        )
+
+    return result
+
+
+def print_comparison(results: list[dict[str, Any]]) -> None:
+    if len(results) != 2:
+        return
+    by_backend = {item["backend"]: item for item in results}
+    if "torch" not in by_backend or "ggml" not in by_backend:
+        return
+    torch_result = by_backend["torch"]
+    ggml_result = by_backend["ggml"]
+
+    print("\n=== Backend comparison ===")
+    print("chunk  torch_ttfa_ms  ggml_ttfa_ms  speedup")
+    for chunk_size in torch_result["ttfa"]:
+        t = torch_result["ttfa"][chunk_size]["mean_ms"]
+        g = ggml_result["ttfa"][chunk_size]["mean_ms"]
+        print(f"{chunk_size:>5}  {t:13.1f}  {g:12.1f}  {t / g:7.2f}x")
+
+    for section in ("buffered", "streaming_chunk8"):
+        t = float(np.mean([item["ms_per_frame"] for item in torch_result[section]]))
+        g = float(np.mean([item["ms_per_frame"] for item in ggml_result[section]]))
+        print(f"{section}: torch={t:.1f} ms/frame ggml={g:.1f} ms/frame speedup={t / g:.2f}x")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=["torch", "ggml", "both"], default="both")
+    parser.add_argument("--mode", choices=["custom", "base"], default="custom")
+    parser.add_argument("--model-size", choices=["0.6B", "1.7B"], default="1.7B")
+    parser.add_argument("--quant", default="BF16")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--attn-implementation", default="eager")
+    parser.add_argument("--max-seq-len", type=int, default=2048)
+    parser.add_argument("--max-new-tokens", type=int, default=128)
+    parser.add_argument("--ttfa-runs", type=int, default=3)
+    parser.add_argument("--throughput-runs", type=int, default=2)
+    parser.add_argument("--chunk-sizes", type=parse_chunk_sizes, default=parse_chunk_sizes("2,4,8,16"))
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--language", default="English")
+    parser.add_argument("--speaker", default="aiden")
+    parser.add_argument("--instruct", default="")
+    parser.add_argument("--ref-audio", default="ref_audio.wav")
+    parser.add_argument("--ref-text", default=DEFAULT_REF_TEXT)
+    parser.add_argument("--xvec-only", action="store_true")
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--greedy", action="store_true")
+    parser.add_argument("--repetition-penalty", type=float, default=1.05)
+    parser.add_argument("--ggml-cache-dir", default=".cache/qwentts")
+    parser.add_argument("--qwentts-lib")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--json-output", default="bench_results_backends.json")
+    args = parser.parse_args()
+
+    if args.mode == "custom" and args.model_size == "0.6B" and args.quant == "BF16":
+        print("Note: GGUF cache may only contain 0.6B CustomVoice Q4_K_M; use --quant Q4_K_M if needed.")
+
+    backends = ["torch", "ggml"] if args.backend == "both" else [args.backend]
+    results = [run_backend(args, backend) for backend in backends]
+    print_comparison(results)
+
+    path = Path(args.json_output)
+    payload = {
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "results": results,
+    }
+    path.write_text(json.dumps(payload, indent=2))
+    print(f"\nWrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/profile_ggml_ttfa.py
+++ b/benchmarks/profile_ggml_ttfa.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Profile Python-visible and native GGML streaming TTFA phases.
+
+This diagnostic uses the timers exposed by the qwentts.cpp ctypes wrapper
+and parses native `[Profile]` log markers when the loaded `libqwen` contains
+the local timing patch. It separates Python setup/callback plumbing from
+native prompt build, first-frame AR generation, and first codec decode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+from faster_qwen3_tts import FasterQwen3TTS
+
+
+DEFAULT_TEXT = (
+    "Ladies and gentlemen, I have just been informed that this speech is being "
+    "generated faster than I can speak it. Please remain calm."
+)
+DEFAULT_REF_TEXT = (
+    "I'm confused why some people have super short timelines, yet at the same "
+    "time are bullish on scaling up reinforcement learning atop LLMs."
+)
+
+
+def parse_chunk_sizes(value: str) -> list[int]:
+    sizes = [int(part.strip()) for part in value.split(",") if part.strip()]
+    if not sizes:
+        raise argparse.ArgumentTypeError("expected at least one chunk size")
+    if any(size <= 0 for size in sizes):
+        raise argparse.ArgumentTypeError("chunk sizes must be positive")
+    return sizes
+
+
+def mean(records: Iterable[dict[str, Any]], key: str) -> float | None:
+    values = [float(record[key]) for record in records if record.get(key) is not None]
+    if not values:
+        return None
+    return statistics.mean(values)
+
+
+def ms(value: float | None) -> str:
+    if value is None:
+        return "   n/a"
+    return f"{value:6.1f}"
+
+
+def parse_native_profile_event(message: str) -> dict[str, Any] | None:
+    if not message.startswith("[Profile] "):
+        return None
+    event: dict[str, Any] = {}
+    for part in message[len("[Profile] ") :].split():
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        try:
+            if "." in value:
+                event[key] = float(value)
+            else:
+                event[key] = int(value)
+        except ValueError:
+            event[key] = value
+    return event
+
+
+def first_chunk(
+    model: FasterQwen3TTS,
+    args: argparse.Namespace,
+    *,
+    chunk_size: int,
+) -> dict[str, Any]:
+    kwargs = {
+        "text": args.text,
+        "language": args.language,
+        "max_new_tokens": max(args.max_new_tokens, chunk_size),
+        "temperature": args.temperature,
+        "top_k": args.top_k,
+        "top_p": args.top_p,
+        "do_sample": not args.greedy,
+        "repetition_penalty": args.repetition_penalty,
+        "chunk_size": chunk_size,
+    }
+
+    if args.mode == "custom":
+        stream = model.generate_custom_voice_streaming(
+            speaker=args.speaker,
+            instruct=args.instruct or None,
+            **kwargs,
+        )
+    elif args.mode == "design":
+        stream = model.generate_voice_design_streaming(
+            instruct=args.instruct,
+            **kwargs,
+        )
+    else:
+        stream = model.generate_voice_clone_streaming(
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            xvec_only=args.xvec_only,
+            **kwargs,
+        )
+
+    if hasattr(args, "_native_logs"):
+        args._native_logs.clear()
+
+    t0 = time.perf_counter()
+    try:
+        chunk, sr, timing = next(stream)
+        ttfa_ms = (time.perf_counter() - t0) * 1000
+    finally:
+        stream.close()
+
+    profile = timing.get("ggml_profile") or {}
+    native_logs = list(getattr(args, "_native_logs", []))
+    native_events = [
+        event for event in (parse_native_profile_event(item["message"]) for item in native_logs) if event is not None
+    ]
+    native_by_phase = {
+        str(event["phase"]): event
+        for event in native_events
+        if "phase" in event
+    }
+    return {
+        "chunk_size": chunk_size,
+        "ttfa_ms": ttfa_ms,
+        "audio_samples": int(len(chunk)),
+        "audio_s": float(len(chunk)) / int(sr),
+        "adapter_prepare_ms": timing.get("adapter_prepare_ms"),
+        "make_params_ms": profile.get("make_params_ms"),
+        "lock_wait_ms": profile.get("lock_wait_ms"),
+        "native_enter_ms": profile.get("native_enter_ms"),
+        "first_callback_enter_ms": profile.get("first_callback_enter_ms"),
+        "first_callback_to_yield_ms": profile.get("first_callback_to_yield_ms"),
+        "first_callback_copy_ms": profile.get("first_callback_copy_ms"),
+        "first_callback_queue_ms": profile.get("first_callback_queue_ms"),
+        "first_callback_n_samples": profile.get("first_callback_n_samples"),
+        "callback_count_at_yield": profile.get("callback_count"),
+        "native_profile_events": native_events,
+        "native_prompt_build_done_ms": native_by_phase.get("prompt_build_done", {}).get("total_ms"),
+        "native_step0_talker_prefill_done_ms": native_by_phase.get("step0_talker_prefill_done", {}).get("total_ms"),
+        "native_step0_code_predictor_done_ms": native_by_phase.get("step0_code_predictor_done", {}).get("total_ms"),
+        "native_step0_frame_done_ms": native_by_phase.get("step0_frame_done", {}).get("total_ms"),
+        "native_first_emit_push_enter_ms": native_by_phase.get("first_emit_push_enter", {}).get("total_ms"),
+        "native_first_emit_done_ms": native_by_phase.get("first_emit_done", {}).get("total_ms"),
+        "native_first_emit_codec_decode_ms": native_by_phase.get("first_emit_done", {}).get("codec_decode_ms"),
+        "native_logs": native_logs,
+        "raw_timing": timing,
+    }
+
+
+def print_summary(records: list[dict[str, Any]]) -> None:
+    by_chunk: dict[int, list[dict[str, Any]]] = {}
+    for record in records:
+        by_chunk.setdefault(int(record["chunk_size"]), []).append(record)
+
+    print()
+    print(
+        "chunk  runs  ttfa  native_enter  first_callback  cb_to_yield  "
+        "make_params  lock_wait  cb_copy"
+    )
+    print("-" * 88)
+    for chunk_size, chunk_records in sorted(by_chunk.items()):
+        print(
+            f"{chunk_size:5d}  {len(chunk_records):4d}  "
+            f"{ms(mean(chunk_records, 'ttfa_ms'))}  "
+            f"{ms(mean(chunk_records, 'native_enter_ms'))}  "
+            f"{ms(mean(chunk_records, 'first_callback_enter_ms'))}  "
+            f"{ms(mean(chunk_records, 'first_callback_to_yield_ms'))}  "
+            f"{ms(mean(chunk_records, 'make_params_ms'))}  "
+            f"{ms(mean(chunk_records, 'lock_wait_ms'))}  "
+            f"{ms(mean(chunk_records, 'first_callback_copy_ms'))}"
+        )
+
+    if any(record.get("native_prompt_build_done_ms") is not None for record in records):
+        print()
+        print(
+            "chunk  prompt  step0_prefill  step0_cp  step0_done  "
+            "emit_enter  emit_done  codec_decode"
+        )
+        print("-" * 84)
+        for chunk_size, chunk_records in sorted(by_chunk.items()):
+            print(
+                f"{chunk_size:5d}  "
+                f"{ms(mean(chunk_records, 'native_prompt_build_done_ms'))}  "
+                f"{ms(mean(chunk_records, 'native_step0_talker_prefill_done_ms'))}  "
+                f"{ms(mean(chunk_records, 'native_step0_code_predictor_done_ms'))}  "
+                f"{ms(mean(chunk_records, 'native_step0_frame_done_ms'))}  "
+                f"{ms(mean(chunk_records, 'native_first_emit_push_enter_ms'))}  "
+                f"{ms(mean(chunk_records, 'native_first_emit_done_ms'))}  "
+                f"{ms(mean(chunk_records, 'native_first_emit_codec_decode_ms'))}"
+            )
+
+    prompt_phases = [
+        ("prompt_bpe_main_done", "bpe_main"),
+        ("prompt_text_projection_load_done", "proj_load"),
+        ("prompt_special_text_embeds_done", "special_text"),
+        ("prompt_special_codec_embeds_done", "special_codec"),
+        ("prompt_bpe_instruct_done", "bpe_instruct"),
+        ("prompt_instruct_rows_done", "instruct_rows"),
+        ("prompt_role_rows_done", "role_rows"),
+        ("prompt_codec_prefix_done", "codec_prefix"),
+        ("prompt_standard_rows_done", "text_rows"),
+        ("prompt_done", "prompt_done"),
+    ]
+    prompt_values: dict[str, list[float]] = {phase: [] for phase, _ in prompt_phases}
+    for record in records:
+        for event in record.get("native_profile_events", []):
+            phase = event.get("phase")
+            if phase in prompt_values and event.get("total_ms") is not None:
+                prompt_values[phase].append(float(event["total_ms"]))
+    if any(prompt_values.values()):
+        print()
+        print("prompt phase              cumulative_ms")
+        print("-" * 37)
+        for phase, label in prompt_phases:
+            values = prompt_values[phase]
+            if values:
+                print(f"{label:24s} {statistics.mean(values):8.1f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice")
+    parser.add_argument("--mode", choices=["custom", "design", "clone"], default="custom")
+    parser.add_argument("--quant", default="BF16")
+    parser.add_argument("--cache-dir", default=".cache/qwentts")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--qwentts-lib")
+    parser.add_argument("--chunk-sizes", type=parse_chunk_sizes, default=parse_chunk_sizes("2,4,8,16"))
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--max-new-tokens", type=int, default=128)
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--language", default="English")
+    parser.add_argument("--speaker", default="aiden")
+    parser.add_argument(
+        "--instruct",
+        default="Warm, confident narrator with clear diction and a steady pace.",
+    )
+    parser.add_argument("--ref-audio", default="ref_audio.wav")
+    parser.add_argument("--ref-text", default=DEFAULT_REF_TEXT)
+    parser.add_argument("--xvec-only", action="store_true")
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--greedy", action="store_true")
+    parser.add_argument("--repetition-penalty", type=float, default=1.05)
+    parser.add_argument("--show-native-log", action="store_true")
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args()
+
+    if args.runs <= 0:
+        raise SystemExit("--runs must be positive")
+    if args.warmup_runs < 0:
+        raise SystemExit("--warmup-runs cannot be negative")
+
+    model = FasterQwen3TTS.from_pretrained(
+        args.model,
+        backend="ggml",
+        quant=args.quant,
+        cache_dir=args.cache_dir,
+        local_files_only=args.local_files_only,
+        qwentts_library_path=args.qwentts_lib,
+    )
+    args._native_logs = []
+    if hasattr(model.runtime, "set_log_callback"):
+        def log_callback(level: int, message: str) -> None:
+            args._native_logs.append({"level": level, "message": message})
+            if args.show_native_log:
+                print(message)
+
+        model.runtime.set_log_callback(log_callback)
+
+    warmup_chunk = args.chunk_sizes[0]
+    for _ in range(args.warmup_runs):
+        first_chunk(model, args, chunk_size=warmup_chunk)
+
+    records: list[dict[str, Any]] = []
+    for chunk_size in args.chunk_sizes:
+        for run in range(args.runs):
+            record = first_chunk(model, args, chunk_size=chunk_size)
+            record["run"] = run + 1
+            records.append(record)
+            print(
+                f"chunk={chunk_size:2d} run={run + 1:2d} "
+                f"ttfa={record['ttfa_ms']:.1f}ms "
+                f"native_enter={ms(record.get('native_enter_ms')).strip()}ms "
+                f"first_callback={ms(record.get('first_callback_enter_ms')).strip()}ms "
+                f"cb_to_yield={ms(record.get('first_callback_to_yield_ms')).strip()}ms"
+            )
+
+    print_summary(records)
+
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(json.dumps(records, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -11,24 +11,27 @@ ENV DEMO_REQUIRE_LOGIN=1
 ENV USAGE_BUCKET_MOUNT_PATH=/data
 ENV HOME=/tmp
 ENV TORCHINDUCTOR_CACHE_DIR=/tmp/torch_inductor
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv \
-    git ffmpeg libsndfile1 sox \
+    curl git ffmpeg libsndfile1 sox \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY . /app
 
-RUN python3 -m venv "$VIRTUAL_ENV" \
-    && python -m pip install --upgrade pip \
-    && python -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
-    && python -m pip install "qwentts-cpp-python==0.3.0+cu128" \
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && uv python install 3.10 \
+    && uv venv --python 3.10 "$VIRTUAL_ENV" \
+    && "$VIRTUAL_ENV/bin/python" -m pip install --upgrade pip \
+    && "$VIRTUAL_ENV/bin/python" -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
+    && "$VIRTUAL_ENV/bin/python" -m pip install "qwentts-cpp-python==0.3.0+cu128" \
         -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128 \
-    && python -m pip install "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
-    && python -m pip install -r requirements.txt
+    && "$VIRTUAL_ENV/bin/python" -m pip install "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
+    && "$VIRTUAL_ENV/bin/python" -m pip install -r requirements.txt
 
 EXPOSE 7860
 CMD ["python3", "server.py", "--host", "0.0.0.0"]

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -14,6 +14,7 @@ ENV TORCHINDUCTOR_CACHE_DIR=/tmp/torch_inductor
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
+ARG FASTER_QWEN3_TTS_REF=main
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
@@ -30,7 +31,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && "$VIRTUAL_ENV/bin/python" -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
     && "$VIRTUAL_ENV/bin/python" -m pip install "qwentts-cpp-python==0.3.0+cu128" \
         -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128 \
-    && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
+    && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@${FASTER_QWEN3_TTS_REF}" \
     && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt -r requirements.txt
 
 EXPOSE 7860

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -22,7 +22,7 @@ COPY . /app
 
 RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
-    && python3 -m pip install "faster-qwen3-tts[demo,ggml]" \
+    && python3 -m pip install "faster-qwen3-tts[demo,ggml] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
     && python3 -m pip install -r requirements.txt
 
 EXPOSE 7860

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,9 +1,11 @@
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV MODEL_CACHE_SIZE=5
 ENV ACTIVE_MODELS=Qwen/Qwen3-TTS-12Hz-1.7B-Base
+ENV DEMO_DEFAULT_BACKEND=ggml
+ENV DEMO_GGML_QUANT=BF16
 ENV DEMO_WEB_ONLY=1
 ENV DEMO_REQUIRE_LOGIN=1
 ENV USAGE_BUCKET_MOUNT_PATH=/data
@@ -19,8 +21,8 @@ WORKDIR /app
 COPY . /app
 
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --index-url https://download.pytorch.org/whl/cu126 torch torchaudio \
-    && python3 -m pip install "faster-qwen3-tts[demo]" \
+    && python3 -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
+    && python3 -m pip install "faster-qwen3-tts[demo,ggml]" \
     && python3 -m pip install -r requirements.txt
 
 EXPOSE 7860

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -16,7 +16,7 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv \
+    python3 \
     curl git ffmpeg libsndfile1 sox \
     && rm -rf /var/lib/apt/lists/*
 
@@ -34,4 +34,4 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && "$VIRTUAL_ENV/bin/python" -m pip install -r requirements.txt
 
 EXPOSE 7860
-CMD ["python3", "server.py", "--host", "0.0.0.0"]
+CMD ["python", "server.py", "--host", "0.0.0.0"]

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -22,7 +22,9 @@ COPY . /app
 
 RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
-    && python3 -m pip install "faster-qwen3-tts[demo,ggml] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
+    && python3 -m pip install "qwentts-cpp-python==0.3.0+cu128" \
+        -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128 \
+    && python3 -m pip install "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
     && python3 -m pip install -r requirements.txt
 
 EXPOSE 7860

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -11,6 +11,8 @@ ENV DEMO_REQUIRE_LOGIN=1
 ENV USAGE_BUCKET_MOUNT_PATH=/data
 ENV HOME=/tmp
 ENV TORCHINDUCTOR_CACHE_DIR=/tmp/torch_inductor
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv \
@@ -20,12 +22,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY . /app
 
-RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
-    && python3 -m pip install "qwentts-cpp-python==0.3.0+cu128" \
+RUN python3 -m venv "$VIRTUAL_ENV" \
+    && python -m pip install --upgrade pip \
+    && python -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
+    && python -m pip install "qwentts-cpp-python==0.3.0+cu128" \
         -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128 \
-    && python3 -m pip install "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
-    && python3 -m pip install -r requirements.txt
+    && python -m pip install "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
+    && python -m pip install -r requirements.txt
 
 EXPOSE 7860
 CMD ["python3", "server.py", "--host", "0.0.0.0"]

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -25,7 +25,7 @@ COPY . /app
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
     && uv python install 3.10 \
-    && uv venv --python 3.10 "$VIRTUAL_ENV" \
+    && uv venv --python 3.10 --seed "$VIRTUAL_ENV" \
     && "$VIRTUAL_ENV/bin/python" -m pip install --upgrade pip \
     && "$VIRTUAL_ENV/bin/python" -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
     && "$VIRTUAL_ENV/bin/python" -m pip install "qwentts-cpp-python==0.3.0+cu128" \

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -30,8 +30,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && "$VIRTUAL_ENV/bin/python" -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
     && "$VIRTUAL_ENV/bin/python" -m pip install "qwentts-cpp-python==0.3.0+cu128" \
         -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128 \
-    && "$VIRTUAL_ENV/bin/python" -m pip install "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
-    && "$VIRTUAL_ENV/bin/python" -m pip install -r requirements.txt
+    && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@ggml-backend-integration" \
+    && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt -r requirements.txt
 
 EXPOSE 7860
 CMD ["python", "server.py", "--host", "0.0.0.0"]

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -34,4 +34,4 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt -r requirements.txt
 
 EXPOSE 7860
-CMD ["python", "server.py", "--host", "0.0.0.0"]
+CMD ["python", "server.py", "--host", "0.0.0.0", "--no-preload"]

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,7 +2,7 @@
 title: faster-qwen3-tts
 author: andito
 emoji: 🎙
-tags: [text-to-speech, streaming, cuda-graphs]
+tags: [text-to-speech, streaming, cuda-graphs, ggml]
 colorFrom: indigo
 colorTo: blue
 sdk: docker
@@ -19,13 +19,14 @@ preload_from_hub:
 
 # Faster Qwen3-TTS Demo
 
-This Space hosts the demo UI for **faster-qwen3-tts** with streaming audio, TTFA/RTF metrics, voice clone, custom voices, and voice design.
+This Space hosts the demo UI for **faster-qwen3-tts** with streaming audio, TTFA/RTF metrics, voice clone, custom voices, and voice design. It defaults to the GGML/qwentts.cpp backend and includes a Settings toggle to switch between GGML and the Torch CUDA-graph backend for speed comparisons.
 
 ## Run locally (no Docker)
 
 ```bash
-pip install "faster-qwen3-tts[demo]"
-python server.py --model Qwen/Qwen3-TTS-12Hz-0.6B-Base
+pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio
+pip install "faster-qwen3-tts[demo,ggml]" nano-parakeet
+python server.py --backend ggml --model Qwen/Qwen3-TTS-12Hz-0.6B-Base
 # open http://localhost:7860
 ```
 
@@ -67,6 +68,9 @@ DEMO_WEB_TOKEN_TTL_SECONDS=7200  # token lifetime
 DEMO_WEB_GATE_SECRET=...         # optional stable signing secret
 DEMO_USAGE_HASH_SECRET=...       # stable Space Secret for pseudonymous quota IDs
 DEMO_DAILY_FREE_REQUESTS=10      # non-PRO daily generation limit
+DEMO_DEFAULT_BACKEND=ggml        # ggml or torch
+DEMO_AVAILABLE_BACKENDS=ggml,torch
+DEMO_GGML_QUANT=BF16
 USAGE_BUCKET_MOUNT_PATH=/data    # attached HF Storage Bucket mount path
 USAGE_DB_FILENAME=faster-qwen3-tts-usage.sqlite3
 USAGE_DB_PATH=/data/usage.sqlite3 # optional full path override

--- a/demo/README.md
+++ b/demo/README.md
@@ -25,7 +25,9 @@ This Space hosts the demo UI for **faster-qwen3-tts** with streaming audio, TTFA
 
 ```bash
 pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio
-pip install "faster-qwen3-tts[demo,ggml]" nano-parakeet
+pip install "qwentts-cpp-python==0.3.0+cu128" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
+pip install "faster-qwen3-tts[demo]" nano-parakeet
 python server.py --backend ggml --model Qwen/Qwen3-TTS-12Hz-0.6B-Base
 # open http://localhost:7860
 ```

--- a/demo/constraints.txt
+++ b/demo/constraints.txt
@@ -1,0 +1,3 @@
+transformers==4.57.3
+huggingface-hub==0.36.2
+tokenizers==0.22.2

--- a/demo/index.html
+++ b/demo/index.html
@@ -588,6 +588,9 @@ body {
   background: var(--surface2); color: var(--text);
   box-shadow: var(--shadow);
 }
+.tog.disabled {
+  opacity: 0.35; cursor: not-allowed; pointer-events: none;
+}
 
 /* Slider */
 .s-slider {
@@ -647,7 +650,7 @@ body {
   <!-- Header -->
   <header class="hdr">
     <h1>faster-qwen3-tts</h1>
-    <span class="badge">CUDA GRAPHS</span>
+    <span class="badge" id="backendBadge">GGML</span>
     <span class="spacer"></span>
     <a class="upill" id="userPill" href="/oauth/huggingface/logout" title="Logout"></a>
     <button class="mpill" onclick="openSettings()" title="Settings">
@@ -754,6 +757,7 @@ body {
         <button class="dl-btn" onclick="dlAudio()" title="Download WAV">&darr;</button>
       </div>
       <div class="metrics">
+        <div class="met"><span class="met-k">Backend</span><span class="met-v" id="mBackend">&mdash;</span></div>
         <div class="met"><span class="met-k">TTFA</span><span class="met-v" id="mTTFA">&mdash;</span></div>
         <div class="met"><span class="met-k">Client</span><span class="met-v" id="mClient">&mdash;</span></div>
         <div class="met" id="mCloneWrap" style="display:none"><span class="met-k">Clone</span><span class="met-v" id="mClone">&mdash;</span></div>
@@ -781,6 +785,13 @@ body {
     </div>
 
     <div class="s-section">Model</div>
+    <div class="s-row">
+      <label>Backend</label>
+      <div class="toggle" id="backendToggle">
+        <div class="tog on" data-b="ggml" onclick="setBackend('ggml', true)">GGML</div>
+        <div class="tog" data-b="torch" onclick="setBackend('torch', true)">Graphs</div>
+      </div>
+    </div>
     <div class="s-row">
       <label>Model</label>
       <select id="modelSel"></select>
@@ -894,6 +905,10 @@ let presetRefId = null;
 let presetRefs = [];
 let loadedModel  = null;
 let loadingModel = null;
+let selectedBackend = 'ggml';
+let loadedBackend = null;
+let loadingBackend = null;
+let availableBackends = ['ggml', 'torch'];
 let dlBlob   = null;
 let currentUsage = null;
 
@@ -980,6 +995,30 @@ function defaultNonStreamingModeForModel(modelId) {
 function syncTextFeedDefault(modelId) {
   if (!modelId) return;
   setNonStreamingMode(defaultNonStreamingModeForModel(modelId));
+}
+function backendLabel(backend) {
+  return backend === 'torch' ? 'Graphs' : 'GGML';
+}
+function setBackend(backend, autoLoad = false) {
+  if (!availableBackends.includes(backend)) return;
+  selectedBackend = backend;
+  updateBackendUI();
+  if (autoLoad && loadedModel && !busy) loadModel().catch(() => {});
+}
+function applyAvailableBackends(backends, defaultBackend, activeBackend) {
+  availableBackends = (backends && backends.length ? backends : [defaultBackend || 'ggml']);
+  selectedBackend = activeBackend || defaultBackend || selectedBackend;
+  if (!availableBackends.includes(selectedBackend)) selectedBackend = availableBackends[0];
+  updateBackendUI();
+}
+function updateBackendUI() {
+  document.querySelectorAll('.tog[data-b]').forEach(el => {
+    const enabled = availableBackends.includes(el.dataset.b);
+    el.classList.toggle('on', el.dataset.b === selectedBackend);
+    el.classList.toggle('disabled', !enabled);
+  });
+  const badgeBackend = loadedBackend || selectedBackend;
+  $('backendBadge').textContent = backendLabel(badgeBackend).toUpperCase();
 }
 function setXvec(v) {
   xvecOnly = v;
@@ -1076,16 +1115,23 @@ async function fetchStatus() {
     if (!res.ok) throw new Error('Status failed');
     const d = await res.json();
     renderUser(d.user, d.usage);
+    applyAvailableBackends(d.available_backends || [], d.default_backend || 'ggml', d.backend || null);
     applyAvailableModels(d.available_models || []);
     if (d.loaded && d.model) {
       // Only trust loadedModel when the server confirms it's actually loaded
       loadedModel = d.model;
+      loadedBackend = d.backend || selectedBackend;
       $('modelSel').value = d.model;
       syncTextFeedDefault(d.model);
+    } else {
+      loadedModel = null;
+      loadedBackend = null;
     }
+    loadingModel = d.loading ? d.loading_model : null;
+    loadingBackend = d.loading ? d.loading_backend : null;
     populateSpeakers(d.speakers || []);
     renderPresetRefs(d.preset_refs || []);
-    setPill(d.loaded ? 'loaded' : 'off', d.loaded ? 'ready' : 'not loaded');
+    setPill(d.loaded ? 'loaded' : 'off', d.loaded ? `${backendLabel(loadedBackend)} ready` : 'not loaded');
   } catch { setPill('off', 'offline'); }
 }
 
@@ -1108,25 +1154,32 @@ async function loadModel() {
   const btn = $('loadBtn');
   btn.disabled = true; btn.textContent = 'Loading...';
   loadingModel = $('modelSel').value;
+  loadingBackend = selectedBackend;
   loadedModel  = null;
+  loadedBackend = null;
   setPlayBtns(true);
-  setPill('loading', 'loading...');
+  setPill('loading', `${backendLabel(loadingBackend)} loading...`);
   try {
     const fd = new FormData();
     fd.append('model_id', loadingModel);
+    fd.append('backend', loadingBackend);
     const d = await fetch('/load', { method: 'POST', headers: webHeaders(), body: fd }).then(r => r.json());
     if (d.status === 'loaded' || d.status === 'already_loaded') {
       loadedModel  = loadingModel;
+      loadedBackend = loadingBackend;
       loadingModel = null;
+      loadingBackend = null;
       syncTextFeedDefault(loadedModel);
-      setPill('loaded', 'ready');
+      setPill('loaded', `${backendLabel(loadedBackend)} ready`);
       fetchStatus();
     } else {
       loadingModel = null;
+      loadingBackend = null;
       setPill('error', 'failed');
     }
   } catch {
     loadingModel = null;
+    loadingBackend = null;
     setPill('error', 'error');
   }
   btn.disabled = false; btn.textContent = 'Load';
@@ -1136,6 +1189,7 @@ async function loadModel() {
 function setPill(state, label) {
   $('mdot').className = 'mdot ' + state;
   $('mtext').textContent = label;
+  updateBackendUI();
   updateModeRows();
 }
 
@@ -1612,6 +1666,10 @@ function buildFinalWav() {
 // ── Generate ──────────────────────────────────────────────────────────────────
 async function generate(mode) {
   if (busy) return;
+  if (!loadedModel || loadedBackend !== selectedBackend) {
+    showMsg('warn', `Load ${backendLabel(selectedBackend)} first.`);
+    return;
+  }
 
   const isVD = loadedModel?.includes('VoiceDesign');
   const isCV = loadedModel?.includes('CustomVoice');
@@ -1721,11 +1779,13 @@ async function runStream(fd) {
         if (!audioInited) { await initAudio(d.sample_rate); audioInited = true; }
         // Capture server wall time on first chunk
         if (firstChunkAt == null && d.elapsed_ms != null) firstServerWall = d.elapsed_ms;
+        setResultBackend(d.backend);
         pushMetrics(d.ttfa_ms, d.rtf, d.total_audio_s, d.voice_clone_ms);
         enqueueChunk(d.audio_b64);
 
       } else if (d.type === 'done') {
         $('queueBar').className = 'queue-bar';
+        setResultBackend(d.backend);
         pushMetrics(d.ttfa_ms, d.rtf, d.total_audio_s, d.voice_clone_ms);
         await chunkQ;
         setDone();
@@ -1746,6 +1806,7 @@ async function runNonStream(fd) {
   if (!res.ok) { const e = await res.json(); throw new Error(e.detail || 'Request failed'); }
   const d = await res.json();
   const m = d.metrics;
+  setResultBackend(d.backend);
   pushMetrics(m.total_ms, m.rtf, m.audio_duration_s, m.voice_clone_ms);
   setDone();
   const bytes = Uint8Array.from(atob(d.audio_b64), c => c.charCodeAt(0));
@@ -1757,7 +1818,11 @@ async function runNonStream(fd) {
 // ── Metrics ───────────────────────────────────────────────────────────────────
 function resetMetrics() {
   ['mTTFA', 'mClient', 'mRTF', 'mDur', 'mBuf', 'mClone'].forEach(id => $(id).innerHTML = '&mdash;');
+  setResultBackend(loadedBackend || selectedBackend);
   $('mCloneWrap').style.display = 'none';
+}
+function setResultBackend(backend) {
+  $('mBackend').textContent = backendLabel(backend || loadedBackend || selectedBackend);
 }
 function pushMetrics(ttfa, rtf, dur, cloneMs) {
   if (ttfa    != null) $('mTTFA').textContent  = Math.round(ttfa) + 'ms';

--- a/demo/index.html
+++ b/demo/index.html
@@ -572,6 +572,12 @@ body {
   font-size: 11px; color: var(--dimmer);
   margin: -6px 0 8px 98px;
 }
+.s-hint.warn {
+  display: none;
+  color: #fcd34d;
+}
+:root[data-theme="light"] .s-hint.warn { color: #a16207; }
+.s-hint.warn.show { display: block; }
 
 /* Toggle */
 .toggle {
@@ -828,6 +834,7 @@ body {
         <div class="tog" data-nsm="1" onclick="setNonStreamingMode(true)">Prefill text</div>
       </div>
     </div>
+    <div class="s-hint warn" id="textFeedWarn">GGML ignores Step-by-step text feed and uses its native prompt layout.</div>
 
     <div class="s-section">Sampling</div>
     <div class="s-grid3">
@@ -988,6 +995,12 @@ function setNonStreamingMode(v) {
   nonStreamingMode = v;
   document.querySelectorAll('.tog[data-nsm]').forEach(el =>
     el.classList.toggle('on', el.dataset.nsm === (v ? '1' : '0')));
+  updateTextFeedWarning();
+}
+function updateTextFeedWarning() {
+  const el = $('textFeedWarn');
+  if (!el) return;
+  el.classList.toggle('show', selectedBackend === 'ggml' && !nonStreamingMode);
 }
 function defaultNonStreamingModeForModel(modelId) {
   return !!modelId && (modelId.includes('CustomVoice') || modelId.includes('VoiceDesign'));
@@ -1003,6 +1016,7 @@ function setBackend(backend, autoLoad = false) {
   if (!availableBackends.includes(backend)) return;
   selectedBackend = backend;
   updateBackendUI();
+  updateTextFeedWarning();
   if (autoLoad && loadedModel && !busy) loadModel().catch(() => {});
 }
 function applyAvailableBackends(backends, defaultBackend, activeBackend) {
@@ -1010,6 +1024,7 @@ function applyAvailableBackends(backends, defaultBackend, activeBackend) {
   selectedBackend = activeBackend || defaultBackend || selectedBackend;
   if (!availableBackends.includes(selectedBackend)) selectedBackend = availableBackends[0];
   updateBackendUI();
+  updateTextFeedWarning();
 }
 function updateBackendUI() {
   document.querySelectorAll('.tog[data-b]').forEach(el => {

--- a/demo/server.py
+++ b/demo/server.py
@@ -76,6 +76,34 @@ if _active_models_env:
 else:
     AVAILABLE_MODELS = list(_ALL_MODELS)
 
+
+def _normalize_backend(value: str | None) -> str:
+    backend = (value or "ggml").strip().lower()
+    if backend == "qwentts":
+        backend = "ggml"
+    if backend not in {"ggml", "torch"}:
+        raise ValueError(f"Unsupported backend: {value!r}")
+    return backend
+
+
+DEFAULT_BACKEND = _normalize_backend(os.environ.get("DEMO_DEFAULT_BACKEND", "ggml"))
+_available_backends_env = os.environ.get("DEMO_AVAILABLE_BACKENDS", "ggml,torch")
+AVAILABLE_BACKENDS = []
+for _backend_value in _available_backends_env.split(","):
+    _backend_value = _backend_value.strip()
+    if not _backend_value:
+        continue
+    _backend = _normalize_backend(_backend_value)
+    if _backend not in AVAILABLE_BACKENDS:
+        AVAILABLE_BACKENDS.append(_backend)
+if not AVAILABLE_BACKENDS:
+    AVAILABLE_BACKENDS = [DEFAULT_BACKEND]
+if DEFAULT_BACKEND not in AVAILABLE_BACKENDS:
+    AVAILABLE_BACKENDS.insert(0, DEFAULT_BACKEND)
+
+GGML_QUANT = os.environ.get("DEMO_GGML_QUANT", "BF16")
+QWENTTS_REF_CACHE_DIR = os.environ.get("DEMO_QWENTTS_REF_CACHE_DIR")
+
 BASE_DIR = Path(__file__).resolve().parent
 INDEX_HTML = BASE_DIR / "index.html"
 # Assets that need to be downloaded at runtime go to a writable directory.
@@ -161,6 +189,8 @@ def _load_preset_refs() -> None:
 
 def _prime_preset_voice_cache(model: FasterQwen3TTS) -> None:
     if not _preset_refs:
+        return
+    if not hasattr(model, "_prepare_generation"):
         return
     for preset in _preset_refs.values():
         ref_path = preset["path"]
@@ -622,10 +652,11 @@ if OAuthError is not None:
     async def oauth_error_handler(request: Request, exc) -> RedirectResponse:
         return RedirectResponse("/", status_code=303)
 
-_model_cache: OrderedDict[str, FasterQwen3TTS] = OrderedDict()
+ModelCacheKey = tuple[str, str]
+_model_cache: OrderedDict[ModelCacheKey, FasterQwen3TTS] = OrderedDict()
 _model_cache_max: int = int(os.environ.get("MODEL_CACHE_SIZE", "2"))
-_active_model_name: str | None = None
-_loading = False
+_active_model_key: ModelCacheKey | None = None
+_loading_key: ModelCacheKey | None = None
 _ref_cache: dict[str, str] = {}
 _ref_cache_lock = threading.Lock()
 _parakeet = None
@@ -679,6 +710,53 @@ def _get_cached_ref_path(content: bytes) -> str:
 
 def _default_non_streaming_mode_for_mode(mode: str) -> bool:
     return mode != "voice_clone"
+
+
+def _active_model_name() -> str | None:
+    return _active_model_key[1] if _active_model_key else None
+
+
+def _active_backend() -> str:
+    return _active_model_key[0] if _active_model_key else DEFAULT_BACKEND
+
+
+def _active_model():
+    return _model_cache.get(_active_model_key) if _active_model_key else None
+
+
+def _model_type_from_id(model_id: str | None) -> str | None:
+    if not model_id:
+        return None
+    if "VoiceDesign" in model_id:
+        return "voice_design"
+    if "CustomVoice" in model_id:
+        return "custom"
+    return "voice_clone"
+
+
+def _load_tts_model(model_id: str, backend: str, *, quant: str | None = None):
+    ggml_quant = quant or GGML_QUANT
+    kwargs = {
+        "backend": backend,
+        "device": "cuda",
+        "dtype": torch.bfloat16,
+    }
+    if backend == "ggml":
+        kwargs.update(
+            {
+                "quant": ggml_quant,
+                "qwentts_ref_cache_dir": QWENTTS_REF_CACHE_DIR,
+            }
+        )
+    model = FasterQwen3TTS.from_pretrained(model_id, **kwargs)
+    if backend == "torch":
+        print("Capturing CUDA graphs…")
+        model._warmup(prefill_len=100)
+        _prime_preset_voice_cache(model)
+        print("CUDA graphs captured — model ready.")
+    else:
+        print(f"GGML/qwentts.cpp model ready ({ggml_quant}).")
+    return model
 
 
 # ─── Routes ───────────────────────────────────────────────────────────────────
@@ -741,19 +819,32 @@ async def transcribe_audio(
 async def get_status(oauth_info = Depends(require_authenticated_user)):
     speakers = []
     model_type = None
-    active = _model_cache.get(_active_model_name) if _active_model_name else None
+    active_model_name = _active_model_name()
+    active_backend = _active_backend()
+    active = _active_model()
     if active is not None:
         try:
             model_type = active.model.model.tts_model_type
-            speakers = active.model.get_supported_speakers() or []
+        except Exception:
+            model_type = _model_type_from_id(active_model_name)
+        try:
+            if hasattr(active, "get_supported_speakers"):
+                speakers = active.get_supported_speakers() or []
+            else:
+                speakers = active.model.get_supported_speakers() or []
         except Exception:
             speakers = []
     user_payload = _user_payload(oauth_info) if REQUIRE_LOGIN else None
     usage_payload = _get_usage(oauth_info) if REQUIRE_LOGIN else None
     return {
         "loaded": active is not None,
-        "model": _active_model_name,
-        "loading": _loading,
+        "model": active_model_name,
+        "backend": active_backend,
+        "default_backend": DEFAULT_BACKEND,
+        "available_backends": AVAILABLE_BACKENDS,
+        "loading": _loading_key is not None,
+        "loading_model": _loading_key[1] if _loading_key else None,
+        "loading_backend": _loading_key[0] if _loading_key else None,
         "available_models": AVAILABLE_MODELS,
         "model_type": model_type,
         "speakers": speakers,
@@ -765,7 +856,10 @@ async def get_status(oauth_info = Depends(require_authenticated_user)):
         "user": user_payload,
         "usage": usage_payload,
         "queue_depth": _generation_waiters,
-        "cached_models": list(_model_cache.keys()),
+        "cached_models": [
+            {"backend": backend, "model": model_id}
+            for backend, model_id in _model_cache.keys()
+        ],
     }
 
 
@@ -791,42 +885,42 @@ async def load_model(
     _user = Depends(require_authenticated_user),
     _web_client: None = Depends(require_web_client),
     model_id: str = Form(...),
+    backend: str = Form(DEFAULT_BACKEND),
 ):
-    global _active_model_name, _loading
+    global _active_model_key, _loading_key
+    try:
+        backend = _normalize_backend(backend)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if backend not in AVAILABLE_BACKENDS:
+        raise HTTPException(status_code=400, detail=f"Backend {backend!r} is not enabled for this demo.")
+    model_key = (backend, model_id)
 
     # Already in cache — instant switch, no GPU work needed
-    if model_id in _model_cache:
-        _active_model_name = model_id
-        _model_cache.move_to_end(model_id)
-        return {"status": "already_loaded", "model": model_id}
+    if model_key in _model_cache:
+        _active_model_key = model_key
+        _model_cache.move_to_end(model_key)
+        return {"status": "already_loaded", "model": model_id, "backend": backend}
 
-    _loading = True
+    _loading_key = model_key
 
     def _do_load():
-        global _active_model_name, _loading
+        global _active_model_key, _loading_key
         try:
             if len(_model_cache) >= _model_cache_max:
                 evicted, _ = _model_cache.popitem(last=False)
-                print(f"Model cache full — evicted: {evicted}")
-            new_model = FasterQwen3TTS.from_pretrained(
-                model_id,
-                device="cuda",
-                dtype=torch.bfloat16,
-            )
-            print("Capturing CUDA graphs…")
-            new_model._warmup(prefill_len=100)
-            _model_cache[model_id] = new_model
-            _model_cache.move_to_end(model_id)
-            _active_model_name = model_id
-            _prime_preset_voice_cache(new_model)
-            print("CUDA graphs captured — model ready.")
+                print(f"Model cache full — evicted: {evicted[0]} {evicted[1]}")
+            new_model = _load_tts_model(model_id, backend)
+            _model_cache[model_key] = new_model
+            _model_cache.move_to_end(model_key)
+            _active_model_key = model_key
         finally:
-            _loading = False
+            _loading_key = None
 
     # Hold the generation lock while loading to prevent OOM from concurrent inference
     async with _generation_lock:
         await asyncio.to_thread(_do_load)
-    return {"status": "loaded", "model": model_id}
+    return {"status": "loaded", "model": model_id, "backend": backend}
 
 
 @app.post("/generate/stream")
@@ -848,7 +942,7 @@ async def generate_stream(
     ref_preset: str = Form(""),
     ref_audio: UploadFile = File(None),
 ):
-    if not _active_model_name or _active_model_name not in _model_cache:
+    if _active_model_key is None or _active_model_key not in _model_cache:
         raise HTTPException(status_code=400, detail="Model not loaded. Click 'Load' first.")
     if len(text) > MAX_TEXT_CHARS:
         raise HTTPException(
@@ -888,9 +982,11 @@ async def generate_stream(
             # Resolve the model after the generation lock is held so we always
             # use the currently active model, not a stale reference captured
             # before a concurrent /load request changed the active model.
-            model = _model_cache.get(_active_model_name)
+            model_key = _active_model_key
+            model = _model_cache.get(model_key)
             if model is None:
                 raise RuntimeError("No model loaded. Please load a model first.")
+            active_backend = model_key[0]
 
             t0 = time.perf_counter()
             total_audio_s = 0.0
@@ -962,6 +1058,7 @@ async def generate_stream(
                 audio_b64 = _to_wav_b64(audio_chunk, sr)
                 payload = {
                     "type": "chunk",
+                    "backend": active_backend,
                     "audio_b64": audio_b64,
                     "sample_rate": sr,
                     "ttfa_ms": round(ttfa_ms),
@@ -986,6 +1083,7 @@ async def generate_stream(
                 audio_b64 = _to_wav_b64(audio_chunk, sr)
                 payload = {
                     "type": "chunk",
+                    "backend": active_backend,
                     "audio_b64": audio_b64,
                     "sample_rate": sr,
                     "ttfa_ms": round(ttfa_ms),
@@ -999,6 +1097,7 @@ async def generate_stream(
             rtf = total_audio_s / (total_gen_ms / 1000) if total_gen_ms > 0 else 0.0
             done_payload = {
                 "type": "done",
+                "backend": active_backend,
                 "ttfa_ms": round(ttfa_ms) if ttfa_ms else 0,
                 "voice_clone_ms": round(voice_clone_ms),
                 "rtf": round(rtf, 3),
@@ -1072,7 +1171,7 @@ async def generate_non_streaming(
     ref_preset: str = Form(""),
     ref_audio: UploadFile = File(None),
 ):
-    if not _active_model_name or _active_model_name not in _model_cache:
+    if _active_model_key is None or _active_model_key not in _model_cache:
         raise HTTPException(status_code=400, detail="Model not loaded. Click 'Load' first.")
     if len(text) > MAX_TEXT_CHARS:
         raise HTTPException(
@@ -1106,9 +1205,11 @@ async def generate_non_streaming(
 
     def run():
         # Resolve the model after the generation lock is held.
-        model = _model_cache.get(_active_model_name)
+        model_key = _active_model_key
+        model = _model_cache.get(model_key)
         if model is None:
             raise RuntimeError("No model loaded. Please load a model first.")
+        active_backend = model_key[0]
         t0 = time.perf_counter()
         if mode == "voice_clone":
             audio_list, sr = model.generate_voice_clone(
@@ -1151,7 +1252,7 @@ async def generate_non_streaming(
         elapsed = time.perf_counter() - t0
         audio = _concat_audio(audio_list)
         dur = len(audio) / sr
-        return audio, sr, elapsed, dur
+        return audio, sr, elapsed, dur, active_backend
 
     global _generation_waiters
     _generation_waiters += 1
@@ -1160,11 +1261,12 @@ async def generate_non_streaming(
         await _generation_lock.acquire()
         lock_acquired = True
         _generation_waiters -= 1
-        audio, sr, elapsed, dur = await asyncio.to_thread(run)
+        audio, sr, elapsed, dur, active_backend = await asyncio.to_thread(run)
         rtf = dur / elapsed if elapsed > 0 else 0.0
         return JSONResponse({
             "audio_b64": _to_wav_b64(audio, sr),
             "sample_rate": sr,
+            "backend": active_backend,
             "metrics": {
                 "total_ms": round(elapsed * 1000),
                 "audio_duration_s": round(dur, 3),
@@ -1183,11 +1285,23 @@ async def generate_non_streaming(
 # ─── Entry point ──────────────────────────────────────────────────────────────
 
 def main():
+    global GGML_QUANT
     parser = argparse.ArgumentParser(description="Faster Qwen3-TTS Demo Server")
     parser.add_argument(
         "--model",
         default="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
         help="Model to preload at startup (default: 1.7B-Base)",
+    )
+    parser.add_argument(
+        "--backend",
+        default=DEFAULT_BACKEND,
+        choices=["ggml", "torch"],
+        help=f"Backend to preload at startup (default: {DEFAULT_BACKEND})",
+    )
+    parser.add_argument(
+        "--quant",
+        default=GGML_QUANT,
+        help=f"GGUF quantization for --backend ggml (default: {GGML_QUANT})",
     )
     parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", 7860)))
     parser.add_argument("--host", default="0.0.0.0")
@@ -1197,20 +1311,16 @@ def main():
         help="Skip model loading at startup (load via UI instead)",
     )
     args = parser.parse_args()
+    GGML_QUANT = args.quant
 
     if not args.no_preload:
-        global _active_model_name, _parakeet
-        print(f"Loading model: {args.model}")
-        _startup_model = FasterQwen3TTS.from_pretrained(
-            args.model,
-            device="cuda",
-            dtype=torch.bfloat16,
-        )
-        print("Capturing CUDA graphs…")
-        _startup_model._warmup(prefill_len=100)
-        _model_cache[args.model] = _startup_model
-        _active_model_name = args.model
-        _prime_preset_voice_cache(_startup_model)
+        global _active_model_key, _parakeet
+        backend = _normalize_backend(args.backend)
+        print(f"Loading model: {args.model} ({backend})")
+        _startup_model = _load_tts_model(args.model, backend)
+        _startup_key = (backend, args.model)
+        _model_cache[_startup_key] = _startup_model
+        _active_model_key = _startup_key
         print("TTS model ready.")
 
         print("Loading transcription model (nano-parakeet)…")

--- a/demo/server.py
+++ b/demo/server.py
@@ -660,6 +660,7 @@ _loading_key: ModelCacheKey | None = None
 _ref_cache: dict[str, str] = {}
 _ref_cache_lock = threading.Lock()
 _parakeet = None
+_parakeet_lock = asyncio.Lock()
 _generation_lock = asyncio.Lock()
 _generation_waiters: int = 0  # requests waiting for or holding the generation lock
 
@@ -792,8 +793,13 @@ async def transcribe_audio(
     audio: UploadFile = File(...),
 ):
     """Transcribe reference audio using nano-parakeet."""
+    global _parakeet
     if _parakeet is None:
-        raise HTTPException(status_code=503, detail="Transcription model not loaded")
+        async with _parakeet_lock:
+            if _parakeet is None:
+                print("Loading transcription model (nano-parakeet)...")
+                _parakeet = await asyncio.to_thread(_parakeet_from_pretrained, device="cuda")
+                print("Transcription model ready.")
 
     content = await audio.read()
     if len(content) > MAX_AUDIO_BYTES:
@@ -1323,7 +1329,7 @@ def main():
         _active_model_key = _startup_key
         print("TTS model ready.")
 
-        print("Loading transcription model (nano-parakeet)…")
+        print("Loading transcription model (nano-parakeet)...")
         _parakeet = _parakeet_from_pretrained(device="cuda")
         print("Transcription model ready.")
 

--- a/docs/ggml-backend.md
+++ b/docs/ggml-backend.md
@@ -32,11 +32,19 @@ pip install "faster-qwen3-tts[ggml]"
 ```
 
 Install a backend-specific wrapper wheel first when the PyPI CUDA 12.8 wheel is
-not the right runtime for the machine, then install this package as usual:
+not the right runtime for the machine, then install this package as usual. Use
+the Hugging Face `+cu128` wheel for Ubuntu 22.04 / older Linux hosts that need
+the `manylinux_2_35` CUDA 12.8 build.
 
 ```bash
+# Ubuntu 22.04 / older Linux with CUDA 12.8
+pip install "qwentts-cpp-python==0.3.0+cu128" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
+
+# CUDA 13 / DGX Spark
 pip install "qwentts-cpp-python==0.3.0+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
+
 pip install "faster-qwen3-tts[ggml]"
 ```
 
@@ -190,8 +198,10 @@ pip install "qwentts-cpp-python==0.3.0+cu130" \
 ```
 
 Hugging Face file hosting is used as a `--find-links` wheelhouse rather than a
-PyTorch-style package index. For CUDA 13 / DGX Spark, install the
-`+cu130` wheel before installing `faster-qwen3-tts[ggml]`.
+PyTorch-style package index. For CUDA 13 / DGX Spark, install the `+cu130`
+wheel before installing `faster-qwen3-tts[ggml]`. For Ubuntu 22.04 / older
+Linux hosts, install `0.3.0+cu128` from the Hugging Face wheelhouse so pip can
+select the `manylinux_2_35` CUDA 12.8 wheel.
 
 For publishing new wrapper wheels, use the manual GitHub Actions workflow:
 

--- a/docs/ggml-backend.md
+++ b/docs/ggml-backend.md
@@ -35,12 +35,12 @@ Install a backend-specific wrapper wheel first when the PyPI CUDA 12.8 wheel is
 not the right runtime for the machine, then install this package as usual:
 
 ```bash
-pip install "qwentts-cpp-python==0.2.0+cu130" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu130.html
+pip install "qwentts-cpp-python==0.3.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 pip install "faster-qwen3-tts[ggml]"
 ```
 
-The same wheel index also has `0.2.0+cu124`, `0.2.0+cu128`, and `0.2.0+cpu`
+The same wheel index also has `0.3.0+cu124`, `0.3.0+cu128`, and `0.3.0+cpu`
 variants.
 
 For local wrapper development, clone the wrapper repo beside this checkout and
@@ -100,7 +100,12 @@ faster-qwen3-tts --backend ggml --quant BF16 design \
   --output out.wav
 ```
 
-Cached qwentts.cpp references are supported for base voice cloning:
+Raw reference audio is cached automatically after the first base voice-clone
+request. The adapter stores qwentts-compatible `.spk` and `.rvq` latents under
+`~/.cache/faster-qwen3-tts/qwentts_refs` by default, or under
+`FQWEN3TTS_QWENTTS_REF_CACHE_DIR` / `--qwentts-ref-cache-dir` when set.
+
+Precomputed qwentts.cpp references are also supported for base voice cloning:
 
 ```python
 audio_list, sr = model.generate_voice_clone(
@@ -113,8 +118,8 @@ audio_list, sr = model.generate_voice_clone(
 ```
 
 Use `ref_spk` by itself for speaker-only conditioning. Use `ref_spk` +
-`ref_rvq` + `ref_text` for cached ICL conditioning. Raw `ref_audio` and cached
-references are mutually exclusive.
+`ref_rvq` + `ref_text` for cached ICL conditioning. Raw `ref_audio` and
+explicit cached references are mutually exclusive.
 
 ## Current ABI Gaps
 
@@ -122,11 +127,9 @@ The qwentts.cpp C ABI is already enough for buffered and streaming
 synthesis, voice cloning, CustomVoice, and VoiceDesign. These gaps remain
 before treating the backend as full parity:
 
-- no C ABI for creating `.spk` / `.rvq` files from `ref_audio` inside Python
 - no `non_streaming_mode` switch
 - base-model `instruct` is rejected by qwentts.cpp
 - KV-cache length is fixed in qwentts.cpp
-- raw reference audio must reach the ABI as mono float 24 kHz
 
 The public GGUF model repo used by the resolver is
 `Serveurperso/Qwen3-TTS-GGUF`.
@@ -168,26 +171,26 @@ The legacy CUDA-graph-only benchmarks still run with `./benchmark.sh`.
 
 ## Wheel Distribution
 
-`qwentts-cpp-python==0.2.0` is published on PyPI. The PyPI package is the
+`qwentts-cpp-python==0.3.0` is published on PyPI. The PyPI package is the
 default CUDA 12.8 wheel used by `pip install "faster-qwen3-tts[ggml]"`.
 Additional local-version wheels are hosted on Hugging Face Hub:
 
 ```bash
-pip install "qwentts-cpp-python==0.2.0+cpu" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cpu.html
+pip install "qwentts-cpp-python==0.3.0+cpu" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cpu
 
-pip install "qwentts-cpp-python==0.2.0+cu124" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu124.html
+pip install "qwentts-cpp-python==0.3.0+cu124" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu124
 
-pip install "qwentts-cpp-python==0.2.0+cu128" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu128.html
+pip install "qwentts-cpp-python==0.3.0+cu128" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
 
-pip install "qwentts-cpp-python==0.2.0+cu130" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu130.html
+pip install "qwentts-cpp-python==0.3.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 ```
 
-Hugging Face raw file hosting is used as a `--find-links` wheelhouse rather
-than a PyTorch-style package index. For CUDA 13 / DGX Spark, install the
+Hugging Face file hosting is used as a `--find-links` wheelhouse rather than a
+PyTorch-style package index. For CUDA 13 / DGX Spark, install the
 `+cu130` wheel before installing `faster-qwen3-tts[ggml]`.
 
 For publishing new wrapper wheels, use the manual GitHub Actions workflow:

--- a/docs/ggml-backend.md
+++ b/docs/ggml-backend.md
@@ -24,11 +24,24 @@ The main package stays installable without native binaries:
 pip install faster-qwen3-tts
 ```
 
-The GGML backend is opt-in:
+The GGML backend is opt-in. By default this installs the PyPI
+`qwentts-cpp-python` wheel, currently the CUDA 12.8 build:
 
 ```bash
 pip install "faster-qwen3-tts[ggml]"
 ```
+
+Install a backend-specific wrapper wheel first when the PyPI CUDA 12.8 wheel is
+not the right runtime for the machine, then install this package as usual:
+
+```bash
+pip install "qwentts-cpp-python==0.2.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu130.html
+pip install "faster-qwen3-tts[ggml]"
+```
+
+The same wheel index also has `0.2.0+cu124`, `0.2.0+cu128`, and `0.2.0+cpu`
+variants.
 
 For local wrapper development, clone the wrapper repo beside this checkout and
 install it in editable mode:
@@ -153,36 +166,41 @@ MODEL_SIZE=0.6B QUANT=BF16 ./benchmark.sh backend-base
 
 The legacy CUDA-graph-only benchmarks still run with `./benchmark.sh`.
 
-## Wheel Build
+## Wheel Distribution
 
-Build native libraries into the wrapper package:
+`qwentts-cpp-python==0.2.0` is published on PyPI. The PyPI package is the
+default CUDA 12.8 wheel used by `pip install "faster-qwen3-tts[ggml]"`.
+Additional local-version wheels are hosted on Hugging Face Hub:
 
 ```bash
-cd ../qwentts-cpp-python
-python scripts/build_native.py --source /path/to/qwentts.cpp --backend cuda --clean
-QWENTTS_CPP_WHEEL_BUILD_TAG=1cu130 python -m build --wheel
+pip install "qwentts-cpp-python==0.2.0+cpu" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cpu.html
+
+pip install "qwentts-cpp-python==0.2.0+cu124" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu124.html
+
+pip install "qwentts-cpp-python==0.2.0+cu128" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu128.html
+
+pip install "qwentts-cpp-python==0.2.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/resolve/main/whl/cu130.html
 ```
 
-The build script copies `libqwen` and `libggml*` into
-`src/qwentts_cpp/lib/`. The package marks itself as a binary distribution
-so the wheel receives a platform tag instead of `py3-none-any`.
+Hugging Face raw file hosting is used as a `--find-links` wheelhouse rather
+than a PyTorch-style package index. For CUDA 13 / DGX Spark, install the
+`+cu130` wheel before installing `faster-qwen3-tts[ggml]`.
 
-The first public release should be CUDA-first. `faster-qwen3-tts` already
-requires CUDA for its existing fast path, so a CPU-only native wheel would be
-surprising and not very useful for the main package audience.
-
-For public CUDA wheels, use the manual GitHub Actions workflow:
+For publishing new wrapper wheels, use the manual GitHub Actions workflow:
 
 ```text
-andimarafioti/qwentts-cpp-python:.github/workflows/wheels.yml
+andimarafioti/qwentts-cpp-python:.github/workflows/publish-hf-wheels.yml
 ```
 
-The workflow builds both Linux x86_64 and Linux aarch64 CUDA wheels as artifacts.
-It installs the CUDA toolkit on GitHub-hosted runners and compiles explicit CUDA
-architectures, so no GPU is required at build time. Download the artifacts and
-test them locally on representative CUDA machines before upload.
+The workflow builds Linux x86_64 and Linux aarch64 wheels for CPU, CUDA 12.4,
+CUDA 12.8, and CUDA 13.0, then uploads static wheel index pages to the HF
+dataset.
 
-Local reproduction mirrors the workflow:
+Local development builds still use the wrapper build script:
 
 ```bash
 cd ../qwentts-cpp-python
@@ -192,34 +210,10 @@ python scripts/build_native.py \
   --clean \
   --cmake-arg=-G \
   --cmake-arg=Ninja \
-  --cmake-arg="-DCMAKE_CUDA_ARCHITECTURES=75-virtual;80-virtual;86-real;89-real;120a-real;121a-real"
-QWENTTS_CPP_WHEEL_BUILD_TAG=1cu130 python -m build --wheel
+  --cmake-arg="-DCMAKE_CUDA_ARCHITECTURES=75-virtual;80-real;86-real;90-real;121-real"
+python -m build --wheel
 ```
-
-Recommended first wheel targets:
-
-- Linux x86_64 CUDA from GitHub Actions
-- Linux aarch64 CUDA from GitHub Actions
-- CPU wheels only as a later fallback package or dev artifact
 
 CUDA-linked `libqwen` depends on CUDA runtime libraries and an NVIDIA driver at
-runtime. That is acceptable for `faster-qwen3-tts[ggml]`, but it means CPU and
-CUDA artifacts should not be uploaded with the same package name, version, and
-platform compatibility tag unless the wheel contains a loader that can select
-between both backends. For local wheelhouses, set a build tag so artifacts do
-not overwrite each other:
-
-```bash
-# CUDA artifact
-python scripts/build_native.py --source /path/to/qwentts.cpp --backend cuda --clean
-QWENTTS_CPP_WHEEL_BUILD_TAG=1cu130 python -m build --wheel
-
-# Optional CPU dev artifact
-python scripts/build_native.py --source /path/to/qwentts.cpp --backend cpu --clean
-QWENTTS_CPP_WHEEL_BUILD_TAG=1cpu python -m build --wheel
-```
-
-For PyPI, CUDA-only under `qwentts-cpp-python` is coherent with this project:
-pip will choose the platform wheel automatically, and users choose only the
-`faster-qwen3-tts[ggml]` extra. CPU support can be a separate distribution or a
-future combined wheel if there is demand.
+runtime. Choose the wrapper wheel that matches the runtime and GPU target first;
+the `faster-qwen3-tts` package only selects the Python adapter.

--- a/docs/ggml-backend.md
+++ b/docs/ggml-backend.md
@@ -135,7 +135,9 @@ The qwentts.cpp C ABI is already enough for buffered and streaming
 synthesis, voice cloning, CustomVoice, and VoiceDesign. These gaps remain
 before treating the backend as full parity:
 
-- no `non_streaming_mode` switch
+- no `non_streaming_mode` switch; requesting
+  `non_streaming_mode=False` emits a warning because qwentts.cpp ignores
+  that step-by-step text-feed mode and uses its native prompt layout
 - base-model `instruct` is rejected by qwentts.cpp
 - KV-cache length is fixed in qwentts.cpp
 

--- a/docs/ggml-backend.md
+++ b/docs/ggml-backend.md
@@ -1,0 +1,225 @@
+# qwentts.cpp GGML Backend
+
+This repo keeps `faster-qwen3-tts` as the user-facing package and adds
+`qwentts-cpp-python` as an optional native runtime package.
+
+## Package Layout
+
+```text
+faster-qwen3-tts
+  Existing Torch/CUDA-graph backend
+  Optional GGML adapter in faster_qwen3_tts.ggml_backend
+
+qwentts-cpp-python
+  Pure Python ctypes wrapper over qwentts.cpp's C ABI
+  Platform wheel packaging for libqwen + libggml
+
+qwentts.cpp
+  Pascal's C++/GGML implementation, built separately with CMake
+```
+
+The main package stays installable without native binaries:
+
+```bash
+pip install faster-qwen3-tts
+```
+
+The GGML backend is opt-in:
+
+```bash
+pip install "faster-qwen3-tts[ggml]"
+```
+
+For local wrapper development, clone the wrapper repo beside this checkout and
+install it in editable mode:
+
+```bash
+git clone https://github.com/andimarafioti/qwentts-cpp-python ../qwentts-cpp-python
+pip install -e ../qwentts-cpp-python
+```
+
+Development build with local native libraries:
+
+```bash
+cd ../qwentts-cpp-python
+python scripts/build_native.py --source /path/to/qwentts.cpp --backend cuda --clean
+pip install -e .
+```
+
+## Python Usage
+
+```python
+from faster_qwen3_tts import FasterQwen3TTS
+
+model = FasterQwen3TTS.from_pretrained(
+    "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+    backend="ggml",
+    quant="BF16",
+)
+
+audio_list, sr = model.generate_voice_design(
+    text="Welcome to the show.",
+    instruct="Warm, confident narrator with slight British accent",
+    language="English",
+)
+```
+
+Local GGUF paths are supported:
+
+```python
+model = FasterQwen3TTS.from_pretrained(
+    "unused",
+    backend="ggml",
+    gguf_talker_path="qwen-talker-1.7b-voicedesign-BF16.gguf",
+    gguf_codec_path="qwen-tokenizer-12hz-BF16.gguf",
+    qwentts_library_path="/path/to/libqwen.so",
+)
+```
+
+CLI usage:
+
+```bash
+faster-qwen3-tts --backend ggml --quant BF16 design \
+  --model Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+  --instruct "Warm, confident narrator" \
+  --text "Welcome to the show." \
+  --language English \
+  --output out.wav
+```
+
+Cached qwentts.cpp references are supported for base voice cloning:
+
+```python
+audio_list, sr = model.generate_voice_clone(
+    text="Cached speaker and RVQ latents avoid reference audio encoding.",
+    language="English",
+    ref_spk="freeman.spk",
+    ref_rvq="freeman.rvq",
+    ref_text="The transcript for the cached reference audio.",
+)
+```
+
+Use `ref_spk` by itself for speaker-only conditioning. Use `ref_spk` +
+`ref_rvq` + `ref_text` for cached ICL conditioning. Raw `ref_audio` and cached
+references are mutually exclusive.
+
+## Current ABI Gaps
+
+The qwentts.cpp C ABI is already enough for buffered and streaming
+synthesis, voice cloning, CustomVoice, and VoiceDesign. These gaps remain
+before treating the backend as full parity:
+
+- no C ABI for creating `.spk` / `.rvq` files from `ref_audio` inside Python
+- no `non_streaming_mode` switch
+- base-model `instruct` is rejected by qwentts.cpp
+- KV-cache length is fixed in qwentts.cpp
+- raw reference audio must reach the ABI as mono float 24 kHz
+
+The public GGUF model repo used by the resolver is
+`Serveurperso/Qwen3-TTS-GGUF`.
+
+## TTFA Profiling
+
+The GGML adapter attaches a `ggml_profile` snapshot to the first streamed
+chunk's `timing` dict. It includes Python-visible boundaries such as ctypes
+parameter packing, lock wait, native `qt_synthesize()` entry, first native
+audio callback, callback copy/queue cost, and first Python yield.
+
+Run the focused diagnostic with:
+
+```bash
+python benchmarks/profile_ggml_ttfa.py \
+  --model Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --mode custom \
+  --speaker aiden \
+  --quant BF16 \
+  --cache-dir .cache/qwentts \
+  --local-files-only \
+  --chunk-sizes 2,4,8,16
+```
+
+With a `libqwen` that includes native profiling markers, the same command also
+prints native phase splits for prompt build, first talker prefill, first code
+predictor step, first emit entry, and first codec decode. Use `--warmup-runs 0`
+to inspect true first-request latency; use the default warmup to inspect
+steady-state server latency after CUDA/GGML graphs and prefix caches are hot.
+
+For a direct Torch-vs-GGML comparison, use the benchmark entry point:
+
+```bash
+MODEL_SIZE=1.7B MODE=custom QUANT=BF16 ./benchmark.sh backends
+MODEL_SIZE=0.6B QUANT=BF16 ./benchmark.sh backend-base
+```
+
+The legacy CUDA-graph-only benchmarks still run with `./benchmark.sh`.
+
+## Wheel Build
+
+Build native libraries into the wrapper package:
+
+```bash
+cd ../qwentts-cpp-python
+python scripts/build_native.py --source /path/to/qwentts.cpp --backend cuda --clean
+QWENTTS_CPP_WHEEL_BUILD_TAG=1cu130 python -m build --wheel
+```
+
+The build script copies `libqwen` and `libggml*` into
+`src/qwentts_cpp/lib/`. The package marks itself as a binary distribution
+so the wheel receives a platform tag instead of `py3-none-any`.
+
+The first public release should be CUDA-first. `faster-qwen3-tts` already
+requires CUDA for its existing fast path, so a CPU-only native wheel would be
+surprising and not very useful for the main package audience.
+
+For public CUDA wheels, use the manual GitHub Actions workflow:
+
+```text
+andimarafioti/qwentts-cpp-python:.github/workflows/wheels.yml
+```
+
+The workflow builds both Linux x86_64 and Linux aarch64 CUDA wheels as artifacts.
+It installs the CUDA toolkit on GitHub-hosted runners and compiles explicit CUDA
+architectures, so no GPU is required at build time. Download the artifacts and
+test them locally on representative CUDA machines before upload.
+
+Local reproduction mirrors the workflow:
+
+```bash
+cd ../qwentts-cpp-python
+python scripts/build_native.py \
+  --source third_party/qwentts.cpp \
+  --backend cuda \
+  --clean \
+  --cmake-arg=-G \
+  --cmake-arg=Ninja \
+  --cmake-arg="-DCMAKE_CUDA_ARCHITECTURES=75-virtual;80-virtual;86-real;89-real;120a-real;121a-real"
+QWENTTS_CPP_WHEEL_BUILD_TAG=1cu130 python -m build --wheel
+```
+
+Recommended first wheel targets:
+
+- Linux x86_64 CUDA from GitHub Actions
+- Linux aarch64 CUDA from GitHub Actions
+- CPU wheels only as a later fallback package or dev artifact
+
+CUDA-linked `libqwen` depends on CUDA runtime libraries and an NVIDIA driver at
+runtime. That is acceptable for `faster-qwen3-tts[ggml]`, but it means CPU and
+CUDA artifacts should not be uploaded with the same package name, version, and
+platform compatibility tag unless the wheel contains a loader that can select
+between both backends. For local wheelhouses, set a build tag so artifacts do
+not overwrite each other:
+
+```bash
+# CUDA artifact
+python scripts/build_native.py --source /path/to/qwentts.cpp --backend cuda --clean
+QWENTTS_CPP_WHEEL_BUILD_TAG=1cu130 python -m build --wheel
+
+# Optional CPU dev artifact
+python scripts/build_native.py --source /path/to/qwentts.cpp --backend cpu --clean
+QWENTTS_CPP_WHEEL_BUILD_TAG=1cpu python -m build --wheel
+```
+
+For PyPI, CUDA-only under `qwentts-cpp-python` is coherent with this project:
+pip will choose the platform wheel automatically, and users choose only the
+`faster-qwen3-tts[ggml]` extra. CPU support can be a separate distribution or a
+future combined wheel if there is demand.

--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -2,6 +2,7 @@
 faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 """
 from .model import FasterQwen3TTS
+from .ggml_backend import GGMLQwen3TTS
 
 __version__ = "0.2.6"
-__all__ = ["FasterQwen3TTS"]
+__all__ = ["FasterQwen3TTS", "GGMLQwen3TTS"]

--- a/faster_qwen3_tts/cli.py
+++ b/faster_qwen3_tts/cli.py
@@ -26,6 +26,7 @@ def _load_model(args):
             qwentts_library_path=args.qwentts_lib,
             qwentts_use_fa=args.qwentts_use_fa,
             qwentts_clamp_fp16=args.qwentts_clamp_fp16,
+            qwentts_ref_cache_dir=args.qwentts_ref_cache_dir,
         )
 
     if dtype == "bf16":
@@ -357,6 +358,7 @@ def build_parser():
     p.add_argument("--gguf-model", help="Local qwentts.cpp talker GGUF path")
     p.add_argument("--gguf-codec", help="Local qwentts.cpp codec GGUF path")
     p.add_argument("--qwentts-lib", help="Explicit path to libqwen shared library")
+    p.add_argument("--qwentts-ref-cache-dir", help="Cache directory for qwentts.cpp cloned voice latents")
     p.add_argument(
         "--qwentts-no-fa",
         dest="qwentts_use_fa",

--- a/faster_qwen3_tts/cli.py
+++ b/faster_qwen3_tts/cli.py
@@ -11,7 +11,21 @@ import torch
 from faster_qwen3_tts import FasterQwen3TTS
 
 
-def _load_model(model_id: str, device: str, dtype: str):
+def _load_model(args):
+    model_id = args.model
+    device = args.device
+    dtype = args.dtype
+
+    if args.backend == "ggml":
+        return FasterQwen3TTS.from_pretrained(
+            model_id,
+            backend="ggml",
+            quant=args.quant,
+            gguf_talker_path=args.gguf_model,
+            gguf_codec_path=args.gguf_codec,
+            qwentts_library_path=args.qwentts_lib,
+        )
+
     if dtype == "bf16":
         torch_dtype = torch.bfloat16
     elif dtype == "fp16":
@@ -43,8 +57,26 @@ def _stream_to_audio(gen):
     return np.concatenate(chunks), sr
 
 
+def _validate_clone_refs(args):
+    has_audio = bool(args.ref_audio)
+    has_cached = bool(args.ref_spk) or bool(args.ref_rvq)
+    if has_audio and has_cached:
+        print("ERROR: --ref-audio cannot be combined with --ref-spk/--ref-rvq")
+        sys.exit(2)
+    if not has_audio and not args.ref_spk:
+        print("ERROR: clone mode requires --ref-audio or --ref-spk")
+        sys.exit(2)
+    if has_audio and not args.xvec_only and not args.ref_text:
+        print("ERROR: --ref-text is required with --ref-audio unless --xvec-only is set")
+        sys.exit(2)
+    if args.ref_rvq and not args.ref_text:
+        print("ERROR: --ref-text is required with --ref-rvq")
+        sys.exit(2)
+
+
 def cmd_clone(args):
-    model = _load_model(args.model, args.device, args.dtype)
+    _validate_clone_refs(args)
+    model = _load_model(args)
 
     if args.streaming:
         start = time.perf_counter()
@@ -53,6 +85,8 @@ def cmd_clone(args):
             language=args.language,
             ref_audio=args.ref_audio,
             ref_text=args.ref_text,
+            ref_spk=args.ref_spk,
+            ref_rvq=args.ref_rvq,
             chunk_size=args.chunk_size,
             max_new_tokens=args.max_new_tokens,
             temperature=args.temperature,
@@ -73,6 +107,8 @@ def cmd_clone(args):
             language=args.language,
             ref_audio=args.ref_audio,
             ref_text=args.ref_text,
+            ref_spk=args.ref_spk,
+            ref_rvq=args.ref_rvq,
             max_new_tokens=args.max_new_tokens,
             temperature=args.temperature,
             top_k=args.top_k,
@@ -91,10 +127,13 @@ def cmd_clone(args):
 
 
 def cmd_custom(args):
-    model = _load_model(args.model, args.device, args.dtype)
+    model = _load_model(args)
 
     if args.list_speakers:
-        speakers = model.model.get_supported_speakers() or []
+        if hasattr(model, "get_supported_speakers"):
+            speakers = model.get_supported_speakers() or []
+        else:
+            speakers = model.model.get_supported_speakers() or []
         print("\n".join(speakers))
         return
 
@@ -143,7 +182,7 @@ def cmd_custom(args):
 
 
 def cmd_design(args):
-    model = _load_model(args.model, args.device, args.dtype)
+    model = _load_model(args)
 
     if args.streaming:
         start = time.perf_counter()
@@ -184,18 +223,16 @@ def cmd_design(args):
 
 
 def cmd_serve(args):
-    model = _load_model(args.model, args.device, args.dtype)
-
     if args.mode == "clone":
-        if not args.ref_audio or not args.ref_text:
-            print("ERROR: --ref-audio and --ref-text are required for clone mode")
-            sys.exit(2)
+        _validate_clone_refs(args)
     if args.mode == "custom" and not args.speaker:
         print("ERROR: --speaker is required for custom mode")
         sys.exit(2)
     if args.mode == "design" and not args.instruct:
         print("ERROR: --instruct is required for design mode")
         sys.exit(2)
+
+    model = _load_model(args)
 
     print("Server started. Enter text per line. Type 'exit' or 'quit' to stop.")
     idx = 1
@@ -218,13 +255,15 @@ def cmd_serve(args):
                     language=args.language,
                     ref_audio=args.ref_audio,
                     ref_text=args.ref_text,
+                    ref_spk=args.ref_spk,
+                    ref_rvq=args.ref_rvq,
                     chunk_size=args.chunk_size,
                     max_new_tokens=args.max_new_tokens,
                     temperature=args.temperature,
                     top_k=args.top_k,
                     do_sample=not args.greedy,
                     repetition_penalty=args.repetition_penalty,
-                    xvec_only=False,
+                    xvec_only=args.xvec_only,
                     non_streaming_mode=args.non_streaming_mode,
                 )
                 audio, sr = _stream_to_audio(gen)
@@ -234,12 +273,14 @@ def cmd_serve(args):
                     language=args.language,
                     ref_audio=args.ref_audio,
                     ref_text=args.ref_text,
+                    ref_spk=args.ref_spk,
+                    ref_rvq=args.ref_rvq,
                     max_new_tokens=args.max_new_tokens,
                     temperature=args.temperature,
                     top_k=args.top_k,
                     do_sample=not args.greedy,
                     repetition_penalty=args.repetition_penalty,
-                    xvec_only=False,
+                    xvec_only=args.xvec_only,
                     non_streaming_mode=args.non_streaming_mode,
                 )
                 audio = audio_list[0]
@@ -309,6 +350,11 @@ def build_parser():
     p = argparse.ArgumentParser(prog="faster-qwen3-tts", description="FasterQwen3TTS CLI")
     p.add_argument("--device", default="cuda", help="Device (cuda or cpu)")
     p.add_argument("--dtype", default="bf16", choices=["bf16", "fp16", "fp32"], help="Model dtype")
+    p.add_argument("--backend", default="torch", choices=["torch", "ggml"], help="Inference backend")
+    p.add_argument("--quant", default="BF16", help="GGUF quant for --backend ggml (BF16, Q8_0, Q4_K_M, F32)")
+    p.add_argument("--gguf-model", help="Local qwentts.cpp talker GGUF path")
+    p.add_argument("--gguf-codec", help="Local qwentts.cpp codec GGUF path")
+    p.add_argument("--qwentts-lib", help="Explicit path to libqwen shared library")
     sub = p.add_subparsers(dest="command", required=True)
 
     def add_common(sp):
@@ -340,8 +386,10 @@ def build_parser():
 
     sp = sub.add_parser("clone", help="Voice cloning (reference audio)")
     add_common(sp)
-    sp.add_argument("--ref-audio", required=True, help="Reference audio path")
-    sp.add_argument("--ref-text", required=True, help="Reference transcript")
+    sp.add_argument("--ref-audio", help="Reference audio path")
+    sp.add_argument("--ref-text", default="", help="Reference transcript")
+    sp.add_argument("--ref-spk", help="Cached qwentts.cpp .spk speaker embedding")
+    sp.add_argument("--ref-rvq", help="Cached qwentts.cpp .rvq acoustic codes")
     sp.add_argument(
         "--xvec-only",
         action="store_true",
@@ -367,7 +415,14 @@ def build_parser():
     sp.add_argument("--model", required=True, help="Model id or local path")
     sp.add_argument("--language", default="Auto", help="Language (Auto, English, French, ...)")
     sp.add_argument("--ref-audio", help="Reference audio path (clone)")
-    sp.add_argument("--ref-text", help="Reference transcript (clone)")
+    sp.add_argument("--ref-text", default="", help="Reference transcript (clone)")
+    sp.add_argument("--ref-spk", help="Cached qwentts.cpp .spk speaker embedding (clone)")
+    sp.add_argument("--ref-rvq", help="Cached qwentts.cpp .rvq acoustic codes (clone)")
+    sp.add_argument(
+        "--xvec-only",
+        action="store_true",
+        help="Use speaker embedding only instead of upstream-default ICL mode",
+    )
     sp.add_argument("--speaker", help="Speaker ID (custom)")
     sp.add_argument("--instruct", default="", help="Instruction (custom/design)")
     sp.add_argument("--streaming", action="store_true", help="Use streaming generation")

--- a/faster_qwen3_tts/cli.py
+++ b/faster_qwen3_tts/cli.py
@@ -24,6 +24,8 @@ def _load_model(args):
             gguf_talker_path=args.gguf_model,
             gguf_codec_path=args.gguf_codec,
             qwentts_library_path=args.qwentts_lib,
+            qwentts_use_fa=args.qwentts_use_fa,
+            qwentts_clamp_fp16=args.qwentts_clamp_fp16,
         )
 
     if dtype == "bf16":
@@ -355,6 +357,18 @@ def build_parser():
     p.add_argument("--gguf-model", help="Local qwentts.cpp talker GGUF path")
     p.add_argument("--gguf-codec", help="Local qwentts.cpp codec GGUF path")
     p.add_argument("--qwentts-lib", help="Explicit path to libqwen shared library")
+    p.add_argument(
+        "--qwentts-no-fa",
+        dest="qwentts_use_fa",
+        action="store_false",
+        help="Disable qwentts.cpp flash-attention kernels for --backend ggml",
+    )
+    p.add_argument(
+        "--qwentts-clamp-fp16",
+        action="store_true",
+        help="Enable qwentts.cpp fp16 clamping for --backend ggml",
+    )
+    p.set_defaults(qwentts_use_fa=True, qwentts_clamp_fp16=False)
     sub = p.add_subparsers(dest="command", required=True)
 
     def add_common(sp):

--- a/faster_qwen3_tts/ggml_backend.py
+++ b/faster_qwen3_tts/ggml_backend.py
@@ -5,7 +5,10 @@ generation to the separately packaged qwentts.cpp C ABI wrapper.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Callable, Generator, Optional, Tuple, Union
@@ -16,6 +19,7 @@ import soundfile as sf
 logger = logging.getLogger(__name__)
 
 _QWEN_FRAME_RATE = 24000 / 1920
+_VOICE_REF_CACHE_VERSION = 1
 
 
 def _require_qwentts_cpp():
@@ -55,13 +59,41 @@ def _load_ref_audio_24k(
     return _resample_linear(np.asarray(audio, dtype=np.float32), int(sr), 24000)
 
 
+def _default_voice_ref_cache_dir() -> Path:
+    env_value = os.environ.get("FQWEN3TTS_QWENTTS_REF_CACHE_DIR")
+    if env_value:
+        return Path(env_value)
+    return Path.home() / ".cache" / "faster-qwen3-tts" / "qwentts_refs"
+
+
+def _path_identity(path: Union[str, Path]) -> str:
+    p = Path(path)
+    try:
+        stat = p.stat()
+        return f"{p.resolve()}:{stat.st_size}:{stat.st_mtime_ns}"
+    except OSError:
+        return str(p)
+
+
 class GGMLQwen3TTS:
     """FasterQwen3TTS-compatible wrapper backed by qwentts.cpp/GGML."""
 
     sample_rate = 24000
 
-    def __init__(self, runtime):
+    def __init__(
+        self,
+        runtime,
+        *,
+        model_identity: str = "unknown",
+        voice_ref_cache_dir: Optional[Union[str, Path]] = None,
+    ):
         self.runtime = runtime
+        self.model_identity = str(model_identity)
+        self.voice_ref_cache_dir = (
+            Path(voice_ref_cache_dir) if voice_ref_cache_dir is not None else _default_voice_ref_cache_dir()
+        )
+        self._voice_ref_cache = {}
+        self.last_adapter_profile: Optional[dict] = None
 
     def get_supported_speakers(self) -> list[str]:
         if not hasattr(self.runtime, "speaker_names"):
@@ -77,6 +109,7 @@ class GGMLQwen3TTS:
         library_path: Optional[Union[str, Path]] = None,
         use_fa: bool = True,
         clamp_fp16: bool = False,
+        voice_ref_cache_dir: Optional[Union[str, Path]] = None,
     ) -> "GGMLQwen3TTS":
         QwenTTS, _load_speaker_embedding = _require_qwentts_cpp()
         runtime = QwenTTS(
@@ -86,7 +119,8 @@ class GGMLQwen3TTS:
             use_fa=use_fa,
             clamp_fp16=clamp_fp16,
         )
-        return cls(runtime)
+        model_identity = f"gguf:{_path_identity(talker_path)}|{_path_identity(codec_path)}"
+        return cls(runtime, model_identity=model_identity, voice_ref_cache_dir=voice_ref_cache_dir)
 
     @classmethod
     def from_pretrained(
@@ -99,6 +133,7 @@ class GGMLQwen3TTS:
         library_path: Optional[Union[str, Path]] = None,
         use_fa: bool = True,
         clamp_fp16: bool = False,
+        voice_ref_cache_dir: Optional[Union[str, Path]] = None,
     ) -> "GGMLQwen3TTS":
         QwenTTS, _load_speaker_embedding = _require_qwentts_cpp()
         runtime = QwenTTS.from_pretrained(
@@ -110,7 +145,11 @@ class GGMLQwen3TTS:
             use_fa=use_fa,
             clamp_fp16=clamp_fp16,
         )
-        return cls(runtime)
+        return cls(
+            runtime,
+            model_identity=f"hf:{model_name}:{quant}",
+            voice_ref_cache_dir=voice_ref_cache_dir,
+        )
 
     def generate_voice_clone(
         self,
@@ -142,7 +181,7 @@ class GGMLQwen3TTS:
             )
         if instruct:
             raise NotImplementedError("qwentts.cpp currently rejects instruct for base voice-clone models")
-        ref_kwargs, _adapter_prepare_ms = self._resolve_clone_reference(
+        ref_kwargs, _adapter_prepare_ms, adapter_profile = self._resolve_clone_reference(
             ref_audio=ref_audio,
             ref_text=ref_text,
             xvec_only=xvec_only,
@@ -152,6 +191,7 @@ class GGMLQwen3TTS:
             ref_spk_emb=ref_spk_emb,
             ref_codes=ref_codes,
         )
+        self.last_adapter_profile = adapter_profile
         audio, sr = self.runtime.synthesize(
             text=text,
             lang=language,
@@ -197,7 +237,7 @@ class GGMLQwen3TTS:
             )
         if instruct:
             raise NotImplementedError("qwentts.cpp currently rejects instruct for base voice-clone models")
-        ref_kwargs, adapter_prepare_ms = self._resolve_clone_reference(
+        ref_kwargs, adapter_prepare_ms, adapter_profile = self._resolve_clone_reference(
             ref_audio=ref_audio,
             ref_text=ref_text,
             xvec_only=xvec_only,
@@ -219,6 +259,7 @@ class GGMLQwen3TTS:
             repetition_penalty=repetition_penalty,
             chunk_size=chunk_size,
             adapter_prepare_ms=adapter_prepare_ms,
+            adapter_profile=adapter_profile,
         )
 
     def _resolve_clone_reference(
@@ -232,8 +273,12 @@ class GGMLQwen3TTS:
         ref_rvq: Optional[Union[str, Path]],
         ref_spk_emb: Optional[np.ndarray],
         ref_codes: Optional[np.ndarray],
-    ) -> Tuple[dict, float]:
+    ) -> Tuple[dict, float, dict]:
         adapter_start = time.perf_counter()
+        adapter_profile = {
+            "mode": "clone",
+            "voice_ref_cache": "explicit" if any(value is not None for value in (ref_spk, ref_rvq, ref_spk_emb, ref_codes)) else "none",
+        }
         has_cached_ref = any(
             value is not None for value in (ref_spk, ref_rvq, ref_spk_emb, ref_codes)
         )
@@ -251,11 +296,17 @@ class GGMLQwen3TTS:
 
         if ref_audio is not None:
             ref_audio_24k = _load_ref_audio_24k(ref_audio, append_silence=append_silence)
-            effective_ref_text = "" if xvec_only else ref_text
-            return {
-                "ref_audio_24k": ref_audio_24k,
-                "ref_text": effective_ref_text or None,
-            }, (time.perf_counter() - adapter_start) * 1000
+            voice_ref, cache_profile = self._get_or_extract_voice_ref(
+                ref_audio_24k,
+                append_silence=append_silence,
+            )
+            adapter_profile.update(cache_profile)
+            ref_kwargs = self._voice_ref_to_kwargs(
+                voice_ref,
+                xvec_only=xvec_only,
+                ref_text=ref_text,
+            )
+            return ref_kwargs, (time.perf_counter() - adapter_start) * 1000, adapter_profile
 
         if not has_cached_ref:
             raise ValueError("Voice cloning requires ref_audio or cached ref_spk/ref_spk_emb.")
@@ -271,7 +322,131 @@ class GGMLQwen3TTS:
         }
         if codes is not None:
             ref_kwargs["ref_codes"] = codes
-        return ref_kwargs, (time.perf_counter() - adapter_start) * 1000
+        return ref_kwargs, (time.perf_counter() - adapter_start) * 1000, adapter_profile
+
+    def _voice_ref_to_kwargs(self, voice_ref, *, xvec_only: bool, ref_text: str) -> dict:
+        include_codes = (not xvec_only) and bool(ref_text)
+        ref_kwargs = {
+            "ref_spk_emb": np.ascontiguousarray(voice_ref.ref_spk_emb, dtype=np.float32).reshape(-1),
+            "ref_text": ref_text if include_codes else None,
+        }
+        if include_codes:
+            ref_kwargs["ref_codes"] = np.ascontiguousarray(voice_ref.ref_codes, dtype=np.int32)
+        return ref_kwargs
+
+    def _get_or_extract_voice_ref(self, ref_audio_24k: np.ndarray, *, append_silence: bool):
+        audio = np.ascontiguousarray(ref_audio_24k, dtype=np.float32).reshape(-1)
+        key, metadata = self._voice_ref_cache_key(audio, append_silence=append_silence)
+        key_short = key[:12]
+        cache_start = time.perf_counter()
+
+        if key in self._voice_ref_cache:
+            return self._voice_ref_cache[key], {
+                "voice_ref_cache": "memory",
+                "voice_ref_cache_key": key_short,
+                "voice_ref_cache_ms": (time.perf_counter() - cache_start) * 1000,
+            }
+
+        cached = self._load_voice_ref_from_disk(key, metadata)
+        if cached is not None:
+            self._voice_ref_cache[key] = cached
+            return cached, {
+                "voice_ref_cache": "disk",
+                "voice_ref_cache_key": key_short,
+                "voice_ref_cache_ms": (time.perf_counter() - cache_start) * 1000,
+            }
+
+        extract = getattr(self.runtime, "extract_voice_ref", None)
+        if extract is None:
+            raise NotImplementedError(
+                "Raw ref_audio caching requires qwentts-cpp-python >= 0.3.0 "
+                "with qt_extract_voice_ref support."
+            )
+
+        extract_start = time.perf_counter()
+        voice_ref = extract(audio)
+        extract_ms = (time.perf_counter() - extract_start) * 1000
+        self._voice_ref_cache[key] = voice_ref
+        self._save_voice_ref_to_disk(key, metadata, voice_ref)
+        profile = {
+            "voice_ref_cache": "miss",
+            "voice_ref_cache_key": key_short,
+            "voice_ref_extract_ms": extract_ms,
+        }
+        native_profile = getattr(self.runtime, "last_extract_voice_ref_profile", None)
+        if native_profile:
+            profile["voice_ref_extract_profile"] = dict(native_profile)
+        return voice_ref, profile
+
+    def _voice_ref_cache_key(self, ref_audio_24k: np.ndarray, *, append_silence: bool) -> tuple[str, dict]:
+        audio_hash = hashlib.sha256(ref_audio_24k.tobytes()).hexdigest()
+        metadata = {
+            "version": _VOICE_REF_CACHE_VERSION,
+            "model_identity": self.model_identity,
+            "native_version": self._runtime_version(),
+            "sample_rate": 24000,
+            "dtype": "float32",
+            "n_samples": int(ref_audio_24k.shape[0]),
+            "append_silence": bool(append_silence),
+            "audio_sha256": audio_hash,
+        }
+        key_payload = json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(key_payload).hexdigest(), metadata
+
+    def _runtime_version(self) -> str:
+        version = getattr(self.runtime, "version", None)
+        if callable(version):
+            try:
+                return str(version())
+            except Exception:
+                pass
+        library = getattr(self.runtime, "library", None)
+        library_version = getattr(library, "version", None)
+        if callable(library_version):
+            try:
+                return str(library_version())
+            except Exception:
+                pass
+        return "unknown"
+
+    def _voice_ref_paths(self, key: str) -> tuple[Path, Path, Path]:
+        base = self.voice_ref_cache_dir / key
+        return base.with_suffix(".spk"), base.with_suffix(".rvq"), base.with_suffix(".json")
+
+    def _load_voice_ref_from_disk(self, key: str, metadata: dict):
+        spk_path, rvq_path, meta_path = self._voice_ref_paths(key)
+        if not (spk_path.is_file() and rvq_path.is_file() and meta_path.is_file()):
+            return None
+        try:
+            cached_metadata = json.loads(meta_path.read_text())
+            if cached_metadata != metadata:
+                return None
+            load_voice_ref = getattr(self.runtime, "load_voice_ref", None)
+            if load_voice_ref is None:
+                return None
+            return load_voice_ref(spk_path, rvq_path)
+        except Exception as exc:
+            logger.warning("Failed to load cached qwentts voice reference %s: %s", key[:12], exc)
+            return None
+
+    def _save_voice_ref_to_disk(self, key: str, metadata: dict, voice_ref) -> None:
+        save = getattr(voice_ref, "save", None)
+        if save is None:
+            return
+        try:
+            self.voice_ref_cache_dir.mkdir(parents=True, exist_ok=True)
+            spk_path, rvq_path, meta_path = self._voice_ref_paths(key)
+            tmp_prefix = self.voice_ref_cache_dir / f".{key}.{os.getpid()}"
+            tmp_spk = tmp_prefix.with_suffix(".spk")
+            tmp_rvq = tmp_prefix.with_suffix(".rvq")
+            tmp_meta = tmp_prefix.with_suffix(".json")
+            save(tmp_spk, tmp_rvq)
+            tmp_meta.write_text(json.dumps(metadata, sort_keys=True))
+            tmp_spk.replace(spk_path)
+            tmp_rvq.replace(rvq_path)
+            tmp_meta.replace(meta_path)
+        except Exception as exc:
+            logger.warning("Failed to save qwentts voice reference cache %s: %s", key[:12], exc)
 
     def _load_cached_speaker(
         self,
@@ -306,7 +481,7 @@ class GGMLQwen3TTS:
         )
         if load_rvq_codes is None:
             raise NotImplementedError(
-                "Cached RVQ references require qwentts-cpp-python >= 0.2.0 "
+                "Cached RVQ references require qwentts-cpp-python >= 0.3.0 "
                 "and qwentts.cpp ABI v2."
             )
         return load_rvq_codes(ref_rvq)
@@ -429,7 +604,14 @@ class GGMLQwen3TTS:
             adapter_prepare_ms=(time.perf_counter() - adapter_start) * 1000,
         )
 
-    def _stream_runtime(self, *, chunk_size: int, adapter_prepare_ms: float = 0.0, **kwargs):
+    def _stream_runtime(
+        self,
+        *,
+        chunk_size: int,
+        adapter_prepare_ms: float = 0.0,
+        adapter_profile: Optional[dict] = None,
+        **kwargs,
+    ):
         chunk_sec = max(1, int(chunk_size)) / _QWEN_FRAME_RATE
         start = time.perf_counter()
         last = start
@@ -443,6 +625,7 @@ class GGMLQwen3TTS:
                 "decode_ms": (now - last) * 1000,
                 "total_ms": (now - start) * 1000,
                 "adapter_prepare_ms": adapter_prepare_ms if idx == 0 else 0.0,
+                "adapter_profile": dict(adapter_profile) if (idx == 0 and adapter_profile) else None,
                 "ggml_profile": dict(native_profile) if native_profile else None,
                 "is_final": False,
             }

--- a/faster_qwen3_tts/ggml_backend.py
+++ b/faster_qwen3_tts/ggml_backend.py
@@ -1,0 +1,449 @@
+"""Optional GGML/qwentts.cpp backend adapter.
+
+This module keeps the public faster-qwen3-tts API shape while delegating
+generation to the separately packaged qwentts.cpp C ABI wrapper.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Callable, Generator, Optional, Tuple, Union
+
+import numpy as np
+import soundfile as sf
+
+logger = logging.getLogger(__name__)
+
+_QWEN_FRAME_RATE = 24000 / 1920
+
+
+def _require_qwentts_cpp():
+    try:
+        from qwentts_cpp import QwenTTS, load_speaker_embedding
+    except ImportError as exc:
+        raise ImportError(
+            "backend='ggml' requires the optional qwentts-cpp-python package. "
+            "Install that package first, then retry with backend='ggml'."
+        ) from exc
+    return QwenTTS, load_speaker_embedding
+
+
+def _resample_linear(audio: np.ndarray, src_sr: int, dst_sr: int = 24000) -> np.ndarray:
+    if src_sr == dst_sr:
+        return np.ascontiguousarray(audio, dtype=np.float32)
+    if audio.size == 0:
+        return np.zeros(0, dtype=np.float32)
+    duration = audio.shape[0] / float(src_sr)
+    dst_n = max(1, int(round(duration * dst_sr)))
+    src_x = np.linspace(0.0, duration, num=audio.shape[0], endpoint=False)
+    dst_x = np.linspace(0.0, duration, num=dst_n, endpoint=False)
+    return np.interp(dst_x, src_x, audio).astype(np.float32)
+
+
+def _load_ref_audio_24k(
+    ref_audio: Union[str, Path],
+    *,
+    append_silence: bool = True,
+    silence_secs: float = 0.5,
+) -> np.ndarray:
+    audio, sr = sf.read(str(ref_audio), dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if append_silence and silence_secs > 0:
+        audio = np.concatenate([audio, np.zeros(int(sr * silence_secs), dtype=np.float32)])
+    return _resample_linear(np.asarray(audio, dtype=np.float32), int(sr), 24000)
+
+
+class GGMLQwen3TTS:
+    """FasterQwen3TTS-compatible wrapper backed by qwentts.cpp/GGML."""
+
+    sample_rate = 24000
+
+    def __init__(self, runtime):
+        self.runtime = runtime
+
+    def get_supported_speakers(self) -> list[str]:
+        if not hasattr(self.runtime, "speaker_names"):
+            return []
+        return list(self.runtime.speaker_names())
+
+    @classmethod
+    def from_gguf(
+        cls,
+        talker_path: Union[str, Path],
+        codec_path: Union[str, Path],
+        *,
+        library_path: Optional[Union[str, Path]] = None,
+        use_fa: bool = True,
+        clamp_fp16: bool = False,
+    ) -> "GGMLQwen3TTS":
+        QwenTTS, _load_speaker_embedding = _require_qwentts_cpp()
+        runtime = QwenTTS(
+            talker_path=talker_path,
+            codec_path=codec_path,
+            library_path=library_path,
+            use_fa=use_fa,
+            clamp_fp16=clamp_fp16,
+        )
+        return cls(runtime)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name: str,
+        *,
+        quant: str = "BF16",
+        cache_dir: Optional[Union[str, Path]] = None,
+        local_files_only: bool = False,
+        library_path: Optional[Union[str, Path]] = None,
+        use_fa: bool = True,
+        clamp_fp16: bool = False,
+    ) -> "GGMLQwen3TTS":
+        QwenTTS, _load_speaker_embedding = _require_qwentts_cpp()
+        runtime = QwenTTS.from_pretrained(
+            model_name,
+            quant=quant,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            library_path=library_path,
+            use_fa=use_fa,
+            clamp_fp16=clamp_fp16,
+        )
+        return cls(runtime)
+
+    def generate_voice_clone(
+        self,
+        text: str,
+        language: str,
+        ref_audio: Optional[Union[str, Path]] = None,
+        ref_text: str = "",
+        max_new_tokens: int = 2048,
+        min_new_tokens: int = 2,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+        xvec_only: bool = False,
+        non_streaming_mode: Optional[bool] = None,
+        append_silence: bool = True,
+        instruct: Optional[str] = None,
+        ref_spk: Optional[Union[str, Path]] = None,
+        ref_rvq: Optional[Union[str, Path]] = None,
+        ref_spk_emb: Optional[np.ndarray] = None,
+        ref_codes: Optional[np.ndarray] = None,
+        voice_clone_prompt=None,
+    ) -> Tuple[list, int]:
+        if voice_clone_prompt is not None:
+            raise NotImplementedError(
+                "The GGML backend cannot consume torch voice_clone_prompt objects; "
+                "use ref_spk/ref_rvq cached qwentts.cpp latents instead."
+            )
+        if instruct:
+            raise NotImplementedError("qwentts.cpp currently rejects instruct for base voice-clone models")
+        ref_kwargs, _adapter_prepare_ms = self._resolve_clone_reference(
+            ref_audio=ref_audio,
+            ref_text=ref_text,
+            xvec_only=xvec_only,
+            append_silence=append_silence,
+            ref_spk=ref_spk,
+            ref_rvq=ref_rvq,
+            ref_spk_emb=ref_spk_emb,
+            ref_codes=ref_codes,
+        )
+        audio, sr = self.runtime.synthesize(
+            text=text,
+            lang=language,
+            **ref_kwargs,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+        )
+        return [audio], sr
+
+    def generate_voice_clone_streaming(
+        self,
+        text: str,
+        language: str,
+        ref_audio: Optional[Union[str, Path]] = None,
+        ref_text: str = "",
+        max_new_tokens: int = 2048,
+        min_new_tokens: int = 2,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+        chunk_size: int = 12,
+        xvec_only: bool = False,
+        non_streaming_mode: Optional[bool] = None,
+        append_silence: bool = True,
+        parity_mode: bool = False,
+        instruct: Optional[str] = None,
+        ref_spk: Optional[Union[str, Path]] = None,
+        ref_rvq: Optional[Union[str, Path]] = None,
+        ref_spk_emb: Optional[np.ndarray] = None,
+        ref_codes: Optional[np.ndarray] = None,
+        voice_clone_prompt=None,
+    ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        if voice_clone_prompt is not None:
+            raise NotImplementedError(
+                "The GGML backend cannot consume torch voice_clone_prompt objects; "
+                "use ref_spk/ref_rvq cached qwentts.cpp latents instead."
+            )
+        if instruct:
+            raise NotImplementedError("qwentts.cpp currently rejects instruct for base voice-clone models")
+        ref_kwargs, adapter_prepare_ms = self._resolve_clone_reference(
+            ref_audio=ref_audio,
+            ref_text=ref_text,
+            xvec_only=xvec_only,
+            append_silence=append_silence,
+            ref_spk=ref_spk,
+            ref_rvq=ref_rvq,
+            ref_spk_emb=ref_spk_emb,
+            ref_codes=ref_codes,
+        )
+        yield from self._stream_runtime(
+            text=text,
+            lang=language,
+            **ref_kwargs,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            chunk_size=chunk_size,
+            adapter_prepare_ms=adapter_prepare_ms,
+        )
+
+    def _resolve_clone_reference(
+        self,
+        *,
+        ref_audio: Optional[Union[str, Path]],
+        ref_text: str,
+        xvec_only: bool,
+        append_silence: bool,
+        ref_spk: Optional[Union[str, Path]],
+        ref_rvq: Optional[Union[str, Path]],
+        ref_spk_emb: Optional[np.ndarray],
+        ref_codes: Optional[np.ndarray],
+    ) -> Tuple[dict, float]:
+        adapter_start = time.perf_counter()
+        has_cached_ref = any(
+            value is not None for value in (ref_spk, ref_rvq, ref_spk_emb, ref_codes)
+        )
+        if ref_audio is not None and has_cached_ref:
+            raise ValueError(
+                "ref_audio is mutually exclusive with cached qwentts.cpp references "
+                "(ref_spk/ref_rvq/ref_spk_emb/ref_codes)."
+            )
+        if ref_spk is not None and ref_spk_emb is not None:
+            raise ValueError("Use either ref_spk or ref_spk_emb, not both.")
+        if ref_rvq is not None and ref_codes is not None:
+            raise ValueError("Use either ref_rvq or ref_codes, not both.")
+        if xvec_only and (ref_rvq is not None or ref_codes is not None):
+            raise ValueError("ref_rvq/ref_codes require ICL mode; set xvec_only=False.")
+
+        if ref_audio is not None:
+            ref_audio_24k = _load_ref_audio_24k(ref_audio, append_silence=append_silence)
+            effective_ref_text = "" if xvec_only else ref_text
+            return {
+                "ref_audio_24k": ref_audio_24k,
+                "ref_text": effective_ref_text or None,
+            }, (time.perf_counter() - adapter_start) * 1000
+
+        if not has_cached_ref:
+            raise ValueError("Voice cloning requires ref_audio or cached ref_spk/ref_spk_emb.")
+
+        spk_emb = self._load_cached_speaker(ref_spk, ref_spk_emb)
+        codes = self._load_cached_codes(ref_rvq, ref_codes)
+        if codes is not None and not ref_text:
+            raise ValueError("ref_text is required when using ref_rvq/ref_codes.")
+
+        ref_kwargs = {
+            "ref_spk_emb": spk_emb,
+            "ref_text": ref_text if codes is not None else None,
+        }
+        if codes is not None:
+            ref_kwargs["ref_codes"] = codes
+        return ref_kwargs, (time.perf_counter() - adapter_start) * 1000
+
+    def _load_cached_speaker(
+        self,
+        ref_spk: Optional[Union[str, Path]],
+        ref_spk_emb: Optional[np.ndarray],
+    ) -> np.ndarray:
+        if ref_spk_emb is not None:
+            spk_emb = np.ascontiguousarray(ref_spk_emb, dtype=np.float32).reshape(-1)
+        elif ref_spk is not None:
+            _QwenTTS, load_speaker_embedding = _require_qwentts_cpp()
+            spk_emb = load_speaker_embedding(ref_spk)
+        else:
+            raise ValueError("ref_spk/ref_spk_emb is required for cached voice cloning.")
+
+        if spk_emb.size == 0:
+            raise ValueError("ref_spk_emb must not be empty.")
+        return spk_emb
+
+    def _load_cached_codes(
+        self,
+        ref_rvq: Optional[Union[str, Path]],
+        ref_codes: Optional[np.ndarray],
+    ) -> Optional[np.ndarray]:
+        if ref_codes is not None:
+            return np.ascontiguousarray(ref_codes, dtype=np.int32)
+        if ref_rvq is None:
+            return None
+        load_rvq_codes: Optional[Callable[..., np.ndarray]] = getattr(
+            self.runtime,
+            "load_rvq_codes",
+            None,
+        )
+        if load_rvq_codes is None:
+            raise NotImplementedError(
+                "Cached RVQ references require qwentts-cpp-python >= 0.1.0a1 "
+                "and qwentts.cpp ABI v2."
+            )
+        return load_rvq_codes(ref_rvq)
+
+    def generate_custom_voice(
+        self,
+        text: str,
+        speaker: str,
+        language: str,
+        instruct: Optional[str] = None,
+        non_streaming_mode: Optional[bool] = None,
+        max_new_tokens: int = 2048,
+        min_new_tokens: int = 2,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+    ) -> Tuple[list, int]:
+        audio, sr = self.runtime.synthesize(
+            text=text,
+            lang=language,
+            speaker=speaker,
+            instruct=instruct or None,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+        )
+        return [audio], sr
+
+    def generate_custom_voice_streaming(
+        self,
+        text: str,
+        speaker: str,
+        language: str,
+        instruct: Optional[str] = None,
+        non_streaming_mode: Optional[bool] = None,
+        max_new_tokens: int = 2048,
+        min_new_tokens: int = 2,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+        chunk_size: int = 12,
+    ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        adapter_start = time.perf_counter()
+        yield from self._stream_runtime(
+            text=text,
+            lang=language,
+            speaker=speaker,
+            instruct=instruct or None,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            chunk_size=chunk_size,
+            adapter_prepare_ms=(time.perf_counter() - adapter_start) * 1000,
+        )
+
+    def generate_voice_design(
+        self,
+        text: str,
+        instruct: str,
+        language: str,
+        non_streaming_mode: Optional[bool] = None,
+        max_new_tokens: int = 2048,
+        min_new_tokens: int = 2,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+    ) -> Tuple[list, int]:
+        audio, sr = self.runtime.synthesize(
+            text=text,
+            lang=language,
+            instruct=instruct,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+        )
+        return [audio], sr
+
+    def generate_voice_design_streaming(
+        self,
+        text: str,
+        instruct: str,
+        language: str,
+        non_streaming_mode: Optional[bool] = None,
+        max_new_tokens: int = 2048,
+        min_new_tokens: int = 2,
+        temperature: float = 0.9,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+        chunk_size: int = 12,
+    ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        adapter_start = time.perf_counter()
+        yield from self._stream_runtime(
+            text=text,
+            lang=language,
+            instruct=instruct,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            chunk_size=chunk_size,
+            adapter_prepare_ms=(time.perf_counter() - adapter_start) * 1000,
+        )
+
+    def _stream_runtime(self, *, chunk_size: int, adapter_prepare_ms: float = 0.0, **kwargs):
+        chunk_sec = max(1, int(chunk_size)) / _QWEN_FRAME_RATE
+        start = time.perf_counter()
+        last = start
+        for idx, (chunk, sr) in enumerate(
+            self.runtime.stream(codec_chunk_sec=chunk_sec, **kwargs)
+        ):
+            now = time.perf_counter()
+            native_profile = getattr(self.runtime, "last_stream_profile", None)
+            yield chunk, sr, {
+                "chunk_index": idx,
+                "decode_ms": (now - last) * 1000,
+                "total_ms": (now - start) * 1000,
+                "adapter_prepare_ms": adapter_prepare_ms if idx == 0 else 0.0,
+                "ggml_profile": dict(native_profile) if native_profile else None,
+                "is_final": False,
+            }
+            last = now

--- a/faster_qwen3_tts/ggml_backend.py
+++ b/faster_qwen3_tts/ggml_backend.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import time
+import warnings
 from pathlib import Path
 from typing import Callable, Generator, Optional, Tuple, Union
 
@@ -20,6 +21,11 @@ logger = logging.getLogger(__name__)
 
 _QWEN_FRAME_RATE = 24000 / 1920
 _VOICE_REF_CACHE_VERSION = 1
+_NON_PREFILL_TEXT_WARNING = (
+    "The GGML backend does not expose Qwen3-TTS step-by-step text feeding "
+    "(`non_streaming_mode=False`); qwentts.cpp ignores this option and uses "
+    "its native prompt layout."
+)
 
 
 def _require_qwentts_cpp():
@@ -73,6 +79,11 @@ def _path_identity(path: Union[str, Path]) -> str:
         return f"{p.resolve()}:{stat.st_size}:{stat.st_mtime_ns}"
     except OSError:
         return str(p)
+
+
+def _warn_non_prefill_text_mode(non_streaming_mode: Optional[bool]) -> None:
+    if non_streaming_mode is False:
+        warnings.warn(_NON_PREFILL_TEXT_WARNING, RuntimeWarning, stacklevel=3)
 
 
 class GGMLQwen3TTS:
@@ -174,6 +185,7 @@ class GGMLQwen3TTS:
         ref_codes: Optional[np.ndarray] = None,
         voice_clone_prompt=None,
     ) -> Tuple[list, int]:
+        _warn_non_prefill_text_mode(non_streaming_mode)
         if voice_clone_prompt is not None:
             raise NotImplementedError(
                 "The GGML backend cannot consume torch voice_clone_prompt objects; "
@@ -230,6 +242,7 @@ class GGMLQwen3TTS:
         ref_codes: Optional[np.ndarray] = None,
         voice_clone_prompt=None,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        _warn_non_prefill_text_mode(non_streaming_mode)
         if voice_clone_prompt is not None:
             raise NotImplementedError(
                 "The GGML backend cannot consume torch voice_clone_prompt objects; "
@@ -501,6 +514,7 @@ class GGMLQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
     ) -> Tuple[list, int]:
+        _warn_non_prefill_text_mode(non_streaming_mode)
         audio, sr = self.runtime.synthesize(
             text=text,
             lang=language,
@@ -531,6 +545,7 @@ class GGMLQwen3TTS:
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        _warn_non_prefill_text_mode(non_streaming_mode)
         adapter_start = time.perf_counter()
         yield from self._stream_runtime(
             text=text,
@@ -561,6 +576,7 @@ class GGMLQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
     ) -> Tuple[list, int]:
+        _warn_non_prefill_text_mode(non_streaming_mode)
         audio, sr = self.runtime.synthesize(
             text=text,
             lang=language,
@@ -589,6 +605,7 @@ class GGMLQwen3TTS:
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
+        _warn_non_prefill_text_mode(non_streaming_mode)
         adapter_start = time.perf_counter()
         yield from self._stream_runtime(
             text=text,

--- a/faster_qwen3_tts/ggml_backend.py
+++ b/faster_qwen3_tts/ggml_backend.py
@@ -306,7 +306,7 @@ class GGMLQwen3TTS:
         )
         if load_rvq_codes is None:
             raise NotImplementedError(
-                "Cached RVQ references require qwentts-cpp-python >= 0.1.0a1 "
+                "Cached RVQ references require qwentts-cpp-python >= 0.2.0 "
                 "and qwentts.cpp ABI v2."
             )
         return load_rvq_codes(ref_rvq)

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -118,6 +118,7 @@ class FasterQwen3TTS:
         qwentts_library_path: Optional[Union[str, Path]] = None,
         qwentts_use_fa: bool = True,
         qwentts_clamp_fp16: bool = False,
+        qwentts_ref_cache_dir: Optional[Union[str, Path]] = None,
         cache_dir: Optional[Union[str, Path]] = None,
         local_files_only: bool = False,
     ):
@@ -138,6 +139,8 @@ class FasterQwen3TTS:
             qwentts_library_path: Optional explicit path to libqwen.
             qwentts_use_fa: Whether qwentts.cpp should use flash-attention kernels.
             qwentts_clamp_fp16: Whether qwentts.cpp should clamp fp16 operations.
+            qwentts_ref_cache_dir: Optional cache directory for GGML voice-clone
+                `.spk` / `.rvq` references extracted from raw reference audio.
             
         Returns:
             FasterQwen3TTS instance
@@ -157,6 +160,7 @@ class FasterQwen3TTS:
                     library_path=qwentts_library_path,
                     use_fa=qwentts_use_fa,
                     clamp_fp16=qwentts_clamp_fp16,
+                    voice_ref_cache_dir=qwentts_ref_cache_dir,
                 )
 
             return GGMLQwen3TTS.from_pretrained(
@@ -167,6 +171,7 @@ class FasterQwen3TTS:
                 library_path=qwentts_library_path,
                 use_fa=qwentts_use_fa,
                 clamp_fp16=qwentts_clamp_fp16,
+                voice_ref_cache_dir=qwentts_ref_cache_dir,
             )
 
         if isinstance(dtype, str):

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -89,6 +89,19 @@ class FasterQwen3TTS:
     ) -> bool:
         """Treat None as the method-specific upstream default."""
         return default if non_streaming_mode is None else non_streaming_mode
+
+    @staticmethod
+    def _reject_ggml_cached_reference_args(
+        ref_spk: Optional[Union[str, Path]],
+        ref_rvq: Optional[Union[str, Path]],
+        ref_spk_emb: Optional[np.ndarray],
+        ref_codes: Optional[np.ndarray],
+    ) -> None:
+        if any(value is not None for value in (ref_spk, ref_rvq, ref_spk_emb, ref_codes)):
+            raise NotImplementedError(
+                "ref_spk/ref_rvq cached qwentts.cpp references require backend='ggml'. "
+                "Use voice_clone_prompt for precomputed prompts with the torch backend."
+            )
         
     @classmethod
     def from_pretrained(
@@ -98,6 +111,13 @@ class FasterQwen3TTS:
         dtype: Union[str, torch.dtype] = torch.bfloat16,
         attn_implementation: str = "sdpa",
         max_seq_len: int = 2048,
+        backend: str = "torch",
+        quant: str = "BF16",
+        gguf_talker_path: Optional[Union[str, Path]] = None,
+        gguf_codec_path: Optional[Union[str, Path]] = None,
+        qwentts_library_path: Optional[Union[str, Path]] = None,
+        cache_dir: Optional[Union[str, Path]] = None,
+        local_files_only: bool = False,
     ):
         """
         Load Qwen3-TTS model and prepare CUDA graphs.
@@ -108,10 +128,39 @@ class FasterQwen3TTS:
             dtype: Data type for inference
             attn_implementation: Attention implementation ("sdpa" or "flash_attention_2")
             max_seq_len: Maximum sequence length for static cache
+            backend: "torch" for the current CUDA graph path, or "ggml" for
+                the optional qwentts.cpp runtime.
+            quant: GGUF quantization used when backend="ggml".
+            gguf_talker_path: Optional local qwentts.cpp talker GGUF path.
+            gguf_codec_path: Optional local qwentts.cpp codec GGUF path.
+            qwentts_library_path: Optional explicit path to libqwen.
             
         Returns:
             FasterQwen3TTS instance
         """
+        if backend not in ("torch", "ggml", "qwentts"):
+            raise ValueError(f"Unsupported backend {backend!r}. Expected 'torch' or 'ggml'.")
+
+        if backend in ("ggml", "qwentts"):
+            from .ggml_backend import GGMLQwen3TTS
+
+            if gguf_talker_path is not None or gguf_codec_path is not None:
+                if gguf_talker_path is None or gguf_codec_path is None:
+                    raise ValueError("Both gguf_talker_path and gguf_codec_path are required for backend='ggml'")
+                return GGMLQwen3TTS.from_gguf(
+                    gguf_talker_path,
+                    gguf_codec_path,
+                    library_path=qwentts_library_path,
+                )
+
+            return GGMLQwen3TTS.from_pretrained(
+                model_name,
+                quant=quant,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                library_path=qwentts_library_path,
+            )
+
         if isinstance(dtype, str):
             dtype = getattr(torch, dtype)
             
@@ -751,6 +800,10 @@ class FasterQwen3TTS:
         non_streaming_mode: Optional[bool] = None,
         append_silence: bool = True,
         instruct: Optional[str] = None,
+        ref_spk: Optional[Union[str, Path]] = None,
+        ref_rvq: Optional[Union[str, Path]] = None,
+        ref_spk_emb: Optional[np.ndarray] = None,
+        ref_codes: Optional[np.ndarray] = None,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> Tuple[list, int]:
         """
@@ -780,6 +833,9 @@ class FasterQwen3TTS:
                 This path supports x-vector-only prompts (`ref_spk_embedding` only)
                 and ICL prompts (`ref_spk_embedding` + `ref_code` + mode flags).
                 `ref_text` is ignored for x-vector-only and required for ICL.
+            ref_spk/ref_rvq/ref_spk_emb/ref_codes: GGML-only cached reference fields.
+                Use `ref_spk` for qwentts.cpp `.spk` files and `ref_rvq` with
+                `ref_text` for cached ICL references.
             instruct: Optional instruction to guide generation style/dialect (e.g.
                 "请用纯正广东话朗读"). Prepended as a user turn before the TTS assistant turn.
                 Experimental for x-vector-only voice cloning; prefer `xvec_only=False`.
@@ -787,6 +843,13 @@ class FasterQwen3TTS:
         Returns:
             Tuple of ([audio_waveform], sample_rate)
         """
+        self._reject_ggml_cached_reference_args(
+            ref_spk=ref_spk,
+            ref_rvq=ref_rvq,
+            ref_spk_emb=ref_spk_emb,
+            ref_codes=ref_codes,
+        )
+
         from .generate import fast_generate
 
         non_streaming_mode = self._resolve_non_streaming_mode(
@@ -884,6 +947,10 @@ class FasterQwen3TTS:
         append_silence: bool = True,
         parity_mode: bool = False,
         instruct: Optional[str] = None,
+        ref_spk: Optional[Union[str, Path]] = None,
+        ref_rvq: Optional[Union[str, Path]] = None,
+        ref_spk_emb: Optional[np.ndarray] = None,
+        ref_codes: Optional[np.ndarray] = None,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         """
@@ -918,6 +985,9 @@ class FasterQwen3TTS:
                 This path supports x-vector-only prompts (`ref_spk_embedding` only)
                 and ICL prompts (`ref_spk_embedding` + `ref_code` + mode flags).
                 `ref_text` is ignored for x-vector-only and required for ICL.
+            ref_spk/ref_rvq/ref_spk_emb/ref_codes: GGML-only cached reference fields.
+                Use `ref_spk` for qwentts.cpp `.spk` files and `ref_rvq` with
+                `ref_text` for cached ICL references.
             instruct: Optional instruction to guide generation style/dialect (e.g.
                 "请用纯正广东话朗读"). Prepended as a user turn before the TTS assistant turn.
                 Experimental for x-vector-only voice cloning; prefer `xvec_only=False`.
@@ -925,6 +995,13 @@ class FasterQwen3TTS:
         Yields:
             Tuple of (audio_chunk_numpy, sample_rate, timing_dict)
         """
+        self._reject_ggml_cached_reference_args(
+            ref_spk=ref_spk,
+            ref_rvq=ref_rvq,
+            ref_spk_emb=ref_spk_emb,
+            ref_codes=ref_codes,
+        )
+
         from .streaming import fast_generate_streaming, parity_generate_streaming
 
         non_streaming_mode = self._resolve_non_streaming_mode(

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -116,6 +116,8 @@ class FasterQwen3TTS:
         gguf_talker_path: Optional[Union[str, Path]] = None,
         gguf_codec_path: Optional[Union[str, Path]] = None,
         qwentts_library_path: Optional[Union[str, Path]] = None,
+        qwentts_use_fa: bool = True,
+        qwentts_clamp_fp16: bool = False,
         cache_dir: Optional[Union[str, Path]] = None,
         local_files_only: bool = False,
     ):
@@ -134,12 +136,14 @@ class FasterQwen3TTS:
             gguf_talker_path: Optional local qwentts.cpp talker GGUF path.
             gguf_codec_path: Optional local qwentts.cpp codec GGUF path.
             qwentts_library_path: Optional explicit path to libqwen.
+            qwentts_use_fa: Whether qwentts.cpp should use flash-attention kernels.
+            qwentts_clamp_fp16: Whether qwentts.cpp should clamp fp16 operations.
             
         Returns:
             FasterQwen3TTS instance
         """
         if backend not in ("torch", "ggml", "qwentts"):
-            raise ValueError(f"Unsupported backend {backend!r}. Expected 'torch' or 'ggml'.")
+            raise ValueError(f"Unsupported backend {backend!r}. Expected 'torch', 'ggml', or 'qwentts'.")
 
         if backend in ("ggml", "qwentts"):
             from .ggml_backend import GGMLQwen3TTS
@@ -151,6 +155,8 @@ class FasterQwen3TTS:
                     gguf_talker_path,
                     gguf_codec_path,
                     library_path=qwentts_library_path,
+                    use_fa=qwentts_use_fa,
+                    clamp_fp16=qwentts_clamp_fp16,
                 )
 
             return GGMLQwen3TTS.from_pretrained(
@@ -159,6 +165,8 @@ class FasterQwen3TTS:
                 cache_dir=cache_dir,
                 local_files_only=local_files_only,
                 library_path=qwentts_library_path,
+                use_fa=qwentts_use_fa,
+                clamp_fp16=qwentts_clamp_fp16,
             )
 
         if isinstance(dtype, str):

--- a/push_space.sh
+++ b/push_space.sh
@@ -6,12 +6,23 @@ set -e
 
 REMOTE=${1:-hf-m4}
 TMP_BRANCH=_hf-deploy-tmp
+PUSH_CMD=(git push "$REMOTE" "$TMP_BRANCH:main" --force)
+
+cleanup() {
+    git branch -D "$TMP_BRANCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 
 echo "Splitting demo/ subtree..."
+git branch -D "$TMP_BRANCH" >/dev/null 2>&1 || true
 git subtree split --prefix demo -b "$TMP_BRANCH"
 
 echo "Pushing to $REMOTE..."
-git push "$REMOTE" "$TMP_BRANCH:main" --force
+if [ -n "${HF_TOKEN:-}" ]; then
+    git -c credential.helper='!f() { echo username=__token__; echo password=$HF_TOKEN; }; f' \
+        push "$REMOTE" "$TMP_BRANCH:main" --force
+else
+    "${PUSH_CMD[@]}"
+fi
 
-git branch -D "$TMP_BRANCH"
 echo "Done."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ggml = [
-    "qwentts-cpp-python>=0.2.0",
+    "qwentts-cpp-python>=0.3.0",
 ]
 demo = [
     "fastapi>=0.100.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+ggml = [
+    "qwentts-cpp-python>=0.1.0a1",
+]
 demo = [
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.24.0",
@@ -49,3 +52,6 @@ faster-qwen3-tts = "faster_qwen3_tts.cli:main"
 [project.urls]
 Homepage = "https://github.com/andimarafioti/faster-qwen3-tts"
 Repository = "https://github.com/andimarafioti/faster-qwen3-tts"
+
+[tool.uv.sources]
+qwentts-cpp-python = { git = "https://github.com/andimarafioti/qwentts-cpp-python", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "qwen-tts>=0.1.1",
-    "transformers>=4.57",
+    "transformers>=4.57,<5",
     "torch>=2.5.1",
     "numpy",
     "soundfile",
-    "huggingface-hub>=0.36.0",
+    "huggingface-hub>=0.36.0,<1.0",
 ]
 
 [project.optional-dependencies]
@@ -43,7 +43,7 @@ demo = [
     "fastapi>=0.100.0",
     "uvicorn[standard]>=0.24.0",
     "python-multipart>=0.0.7",
-    "huggingface-hub[oauth]>=0.36.0",
+    "huggingface-hub[oauth]>=0.36.0,<1.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ggml = [
-    "qwentts-cpp-python>=0.1.0a1",
+    "qwentts-cpp-python>=0.2.0",
 ]
 demo = [
     "fastapi>=0.100.0",
@@ -52,6 +52,3 @@ faster-qwen3-tts = "faster_qwen3_tts.cli:main"
 [project.urls]
 Homepage = "https://github.com/andimarafioti/faster-qwen3-tts"
 Repository = "https://github.com/andimarafioti/faster-qwen3-tts"
-
-[tool.uv.sources]
-qwentts-cpp-python = { git = "https://github.com/andimarafioti/qwentts-cpp-python", branch = "main" }

--- a/tests/test_ggml_backend.py
+++ b/tests/test_ggml_backend.py
@@ -1,17 +1,34 @@
 import sys
 import types
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 from faster_qwen3_tts import FasterQwen3TTS
 from faster_qwen3_tts.cli import build_parser
+import faster_qwen3_tts.ggml_backend as ggml_backend
 from faster_qwen3_tts.ggml_backend import GGMLQwen3TTS
+
+
+class _FakeVoiceRef:
+    def __init__(self, spk=None, codes=None):
+        self.ref_spk_emb = np.array([4.0, 5.0, 6.0], dtype=np.float32) if spk is None else spk
+        self.ref_codes = (
+            np.arange(8, dtype=np.int32).reshape(4, 2)
+            if codes is None
+            else codes
+        )
+
+    def save(self, spk_path, rvq_path):
+        Path(spk_path).write_bytes(b"spk")
+        Path(rvq_path).write_bytes(b"rvq")
 
 
 class _FakeRuntime:
     def __init__(self):
         self.calls = []
+        self.last_extract_voice_ref_profile = None
 
     def synthesize(self, **kwargs):
         self.calls.append(("synthesize", kwargs))
@@ -24,6 +41,23 @@ class _FakeRuntime:
     def load_rvq_codes(self, path):
         self.calls.append(("load_rvq_codes", {"path": path}))
         return np.arange(8, dtype=np.int32).reshape(4, 2)
+
+    def extract_voice_ref(self, ref_audio_24k):
+        self.calls.append(("extract_voice_ref", {"n_samples": int(ref_audio_24k.shape[0])}))
+        self.last_extract_voice_ref_profile = {"native_extract_ms": 12.5}
+        return _FakeVoiceRef()
+
+    def load_voice_ref(self, spk_path, rvq_path):
+        self.calls.append(("load_voice_ref", {"spk_path": spk_path, "rvq_path": rvq_path}))
+        assert Path(spk_path).is_file()
+        assert Path(rvq_path).is_file()
+        return _FakeVoiceRef(
+            spk=np.array([9.0, 10.0, 11.0], dtype=np.float32),
+            codes=np.arange(8, 16, dtype=np.int32).reshape(4, 2),
+        )
+
+    def version(self):
+        return "fake-native"
 
     def speaker_names(self):
         return ["aiden", "vivian"]
@@ -99,6 +133,77 @@ def test_cached_streaming_forwards_adapter_timing(qwentts_cpp_stub):
     _name, kwargs = runtime.calls[0]
     assert kwargs["codec_chunk_sec"] == pytest.approx(4 / 12.5)
     np.testing.assert_array_equal(kwargs["ref_spk_emb"], np.ones(3, dtype=np.float32))
+
+
+def test_raw_ref_audio_uses_memory_voice_ref_cache(monkeypatch, tmp_path):
+    ref_audio_24k = np.array([0.0, 0.25, -0.25], dtype=np.float32)
+    monkeypatch.setattr(
+        ggml_backend,
+        "_load_ref_audio_24k",
+        lambda *_args, **_kwargs: ref_audio_24k,
+    )
+    runtime = _FakeRuntime()
+    model = GGMLQwen3TTS(runtime, model_identity="fake-model", voice_ref_cache_dir=tmp_path)
+
+    first = next(
+        model.generate_voice_clone_streaming(
+            text="hello",
+            language="English",
+            ref_audio="reference.wav",
+            ref_text="reference transcript",
+            chunk_size=4,
+        )
+    )
+    second = next(
+        model.generate_voice_clone_streaming(
+            text="hello again",
+            language="English",
+            ref_audio="reference.wav",
+            ref_text="reference transcript",
+            chunk_size=4,
+        )
+    )
+
+    assert [name for name, _ in runtime.calls].count("extract_voice_ref") == 1
+    assert first[2]["adapter_profile"]["voice_ref_cache"] == "miss"
+    assert second[2]["adapter_profile"]["voice_ref_cache"] == "memory"
+    stream_calls = [kwargs for name, kwargs in runtime.calls if name == "stream"]
+    np.testing.assert_array_equal(stream_calls[0]["ref_spk_emb"], np.array([4.0, 5.0, 6.0], dtype=np.float32))
+    np.testing.assert_array_equal(stream_calls[0]["ref_codes"], np.arange(8, dtype=np.int32).reshape(4, 2))
+
+
+def test_raw_ref_audio_reuses_disk_voice_ref_cache(monkeypatch, tmp_path):
+    ref_audio_24k = np.array([0.0, 0.25, -0.25], dtype=np.float32)
+    monkeypatch.setattr(
+        ggml_backend,
+        "_load_ref_audio_24k",
+        lambda *_args, **_kwargs: ref_audio_24k,
+    )
+
+    first_runtime = _FakeRuntime()
+    first_model = GGMLQwen3TTS(first_runtime, model_identity="fake-model", voice_ref_cache_dir=tmp_path)
+    first_model.generate_voice_clone(
+        text="hello",
+        language="English",
+        ref_audio="reference.wav",
+        ref_text="reference transcript",
+    )
+
+    second_runtime = _FakeRuntime()
+    second_model = GGMLQwen3TTS(second_runtime, model_identity="fake-model", voice_ref_cache_dir=tmp_path)
+    second_model.generate_voice_clone(
+        text="hello",
+        language="English",
+        ref_audio="reference.wav",
+        ref_text="reference transcript",
+    )
+
+    assert [name for name, _ in second_runtime.calls].count("extract_voice_ref") == 0
+    assert [name for name, _ in second_runtime.calls].count("load_voice_ref") == 1
+    assert second_model.last_adapter_profile["voice_ref_cache"] == "disk"
+    _name, kwargs = second_runtime.calls[-1]
+    np.testing.assert_array_equal(kwargs["ref_spk_emb"], np.array([9.0, 10.0, 11.0], dtype=np.float32))
+    np.testing.assert_array_equal(kwargs["ref_codes"], np.arange(8, 16, dtype=np.int32).reshape(4, 2))
 
 
 def test_cached_references_reject_raw_audio_mix(qwentts_cpp_stub):
@@ -189,6 +294,7 @@ def test_public_from_pretrained_forwards_qwentts_runtime_flags(monkeypatch):
         qwentts_library_path="libqwen.so",
         qwentts_use_fa=False,
         qwentts_clamp_fp16=True,
+        qwentts_ref_cache_dir=".cache/refs",
     )
 
     assert result is sentinel
@@ -200,6 +306,7 @@ def test_public_from_pretrained_forwards_qwentts_runtime_flags(monkeypatch):
         "library_path": "libqwen.so",
         "use_fa": False,
         "clamp_fp16": True,
+        "voice_ref_cache_dir": ".cache/refs",
     }
 
 
@@ -226,6 +333,7 @@ def test_public_from_gguf_forwards_qwentts_runtime_flags(monkeypatch):
         qwentts_library_path="libqwen.so",
         qwentts_use_fa=False,
         qwentts_clamp_fp16=True,
+        qwentts_ref_cache_dir=".cache/refs",
     )
 
     assert result is sentinel
@@ -234,6 +342,7 @@ def test_public_from_gguf_forwards_qwentts_runtime_flags(monkeypatch):
         "library_path": "libqwen.so",
         "use_fa": False,
         "clamp_fp16": True,
+        "voice_ref_cache_dir": ".cache/refs",
     }
 
 
@@ -246,6 +355,8 @@ def test_cli_parses_qwentts_runtime_flags():
             "ggml",
             "--qwentts-no-fa",
             "--qwentts-clamp-fp16",
+            "--qwentts-ref-cache-dir",
+            ".cache/refs",
             "design",
             "--model",
             "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
@@ -260,3 +371,4 @@ def test_cli_parses_qwentts_runtime_flags():
 
     assert args.qwentts_use_fa is False
     assert args.qwentts_clamp_fp16 is True
+    assert args.qwentts_ref_cache_dir == ".cache/refs"

--- a/tests/test_ggml_backend.py
+++ b/tests/test_ggml_backend.py
@@ -1,0 +1,129 @@
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from faster_qwen3_tts.ggml_backend import GGMLQwen3TTS
+
+
+class _FakeRuntime:
+    def __init__(self):
+        self.calls = []
+
+    def synthesize(self, **kwargs):
+        self.calls.append(("synthesize", kwargs))
+        return np.array([0.0, 0.25], dtype=np.float32), 24000
+
+    def stream(self, *, codec_chunk_sec, **kwargs):
+        self.calls.append(("stream", {"codec_chunk_sec": codec_chunk_sec, **kwargs}))
+        yield np.array([0.0, 0.25], dtype=np.float32), 24000
+
+    def load_rvq_codes(self, path):
+        self.calls.append(("load_rvq_codes", {"path": path}))
+        return np.arange(8, dtype=np.int32).reshape(4, 2)
+
+    def speaker_names(self):
+        return ["aiden", "vivian"]
+
+
+@pytest.fixture
+def qwentts_cpp_stub(monkeypatch):
+    module = types.SimpleNamespace(
+        QwenTTS=object,
+        load_speaker_embedding=lambda _path: np.array([1.0, 2.0, 3.0], dtype=np.float32),
+    )
+    monkeypatch.setitem(sys.modules, "qwentts_cpp", module)
+    return module
+
+
+def test_cached_speaker_only_forwards_spk_embedding(qwentts_cpp_stub):
+    runtime = _FakeRuntime()
+    model = GGMLQwen3TTS(runtime)
+
+    audio_list, sr = model.generate_voice_clone(
+        text="hello",
+        language="English",
+        ref_spk="speaker.spk",
+        xvec_only=True,
+    )
+
+    assert sr == 24000
+    np.testing.assert_array_equal(audio_list[0], np.array([0.0, 0.25], dtype=np.float32))
+    _name, kwargs = runtime.calls[0]
+    np.testing.assert_array_equal(
+        kwargs["ref_spk_emb"],
+        np.array([1.0, 2.0, 3.0], dtype=np.float32),
+    )
+    assert kwargs["ref_text"] is None
+    assert "ref_audio_24k" not in kwargs
+    assert "ref_codes" not in kwargs
+
+
+def test_cached_icl_forwards_spk_rvq_and_ref_text(qwentts_cpp_stub):
+    runtime = _FakeRuntime()
+    model = GGMLQwen3TTS(runtime)
+
+    model.generate_voice_clone(
+        text="hello",
+        language="English",
+        ref_spk="speaker.spk",
+        ref_rvq="reference.rvq",
+        ref_text="reference transcript",
+    )
+
+    assert runtime.calls[0] == ("load_rvq_codes", {"path": "reference.rvq"})
+    _name, kwargs = runtime.calls[1]
+    np.testing.assert_array_equal(kwargs["ref_codes"], np.arange(8, dtype=np.int32).reshape(4, 2))
+    assert kwargs["ref_text"] == "reference transcript"
+
+
+def test_cached_streaming_forwards_adapter_timing(qwentts_cpp_stub):
+    runtime = _FakeRuntime()
+    model = GGMLQwen3TTS(runtime)
+
+    chunk, sr, timing = next(
+        model.generate_voice_clone_streaming(
+            text="hello",
+            language="English",
+            ref_spk_emb=np.ones(3, dtype=np.float32),
+            chunk_size=4,
+        )
+    )
+
+    assert sr == 24000
+    np.testing.assert_array_equal(chunk, np.array([0.0, 0.25], dtype=np.float32))
+    assert timing["adapter_prepare_ms"] >= 0.0
+    _name, kwargs = runtime.calls[0]
+    assert kwargs["codec_chunk_sec"] == pytest.approx(4 / 12.5)
+    np.testing.assert_array_equal(kwargs["ref_spk_emb"], np.ones(3, dtype=np.float32))
+
+
+def test_cached_references_reject_raw_audio_mix(qwentts_cpp_stub):
+    model = GGMLQwen3TTS(_FakeRuntime())
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        model.generate_voice_clone(
+            text="hello",
+            language="English",
+            ref_audio="reference.wav",
+            ref_spk="speaker.spk",
+        )
+
+
+def test_cached_rvq_requires_ref_text(qwentts_cpp_stub):
+    model = GGMLQwen3TTS(_FakeRuntime())
+
+    with pytest.raises(ValueError, match="ref_text is required"):
+        model.generate_voice_clone(
+            text="hello",
+            language="English",
+            ref_spk="speaker.spk",
+            ref_rvq="reference.rvq",
+        )
+
+
+def test_ggml_speaker_listing_uses_runtime():
+    model = GGMLQwen3TTS(_FakeRuntime())
+
+    assert model.get_supported_speakers() == ["aiden", "vivian"]

--- a/tests/test_ggml_backend.py
+++ b/tests/test_ggml_backend.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -133,6 +134,73 @@ def test_cached_streaming_forwards_adapter_timing(qwentts_cpp_stub):
     _name, kwargs = runtime.calls[0]
     assert kwargs["codec_chunk_sec"] == pytest.approx(4 / 12.5)
     np.testing.assert_array_equal(kwargs["ref_spk_emb"], np.ones(3, dtype=np.float32))
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs", "streaming"),
+    [
+        (
+            "generate_voice_clone",
+            {"text": "hello", "language": "English", "ref_spk_emb": np.ones(3, dtype=np.float32)},
+            False,
+        ),
+        (
+            "generate_voice_clone_streaming",
+            {"text": "hello", "language": "English", "ref_spk_emb": np.ones(3, dtype=np.float32)},
+            True,
+        ),
+        (
+            "generate_custom_voice",
+            {"text": "hello", "speaker": "aiden", "language": "English"},
+            False,
+        ),
+        (
+            "generate_custom_voice_streaming",
+            {"text": "hello", "speaker": "aiden", "language": "English"},
+            True,
+        ),
+        (
+            "generate_voice_design",
+            {"text": "hello", "instruct": "warm voice", "language": "English"},
+            False,
+        ),
+        (
+            "generate_voice_design_streaming",
+            {"text": "hello", "instruct": "warm voice", "language": "English"},
+            True,
+        ),
+    ],
+)
+def test_ggml_warns_when_non_prefill_text_feed_is_requested(
+    qwentts_cpp_stub,
+    method_name,
+    kwargs,
+    streaming,
+):
+    model = GGMLQwen3TTS(_FakeRuntime())
+
+    with pytest.warns(RuntimeWarning, match="step-by-step text feeding"):
+        result = getattr(model, method_name)(non_streaming_mode=False, **kwargs)
+        if streaming:
+            next(result)
+
+
+def test_ggml_does_not_warn_for_prefill_text_feed(qwentts_cpp_stub):
+    model = GGMLQwen3TTS(_FakeRuntime())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        model.generate_custom_voice(
+            text="hello",
+            speaker="aiden",
+            language="English",
+            non_streaming_mode=True,
+        )
+
+    assert not [
+        warning for warning in caught
+        if "step-by-step text feeding" in str(warning.message)
+    ]
 
 
 def test_raw_ref_audio_uses_memory_voice_ref_cache(monkeypatch, tmp_path):

--- a/tests/test_ggml_backend.py
+++ b/tests/test_ggml_backend.py
@@ -4,6 +4,8 @@ import types
 import numpy as np
 import pytest
 
+from faster_qwen3_tts import FasterQwen3TTS
+from faster_qwen3_tts.cli import build_parser
 from faster_qwen3_tts.ggml_backend import GGMLQwen3TTS
 
 
@@ -127,3 +129,134 @@ def test_ggml_speaker_listing_uses_runtime():
     model = GGMLQwen3TTS(_FakeRuntime())
 
     assert model.get_supported_speakers() == ["aiden", "vivian"]
+
+
+def test_adapter_from_pretrained_forwards_qwentts_runtime_flags(monkeypatch, qwentts_cpp_stub):
+    captured = {}
+
+    class FakeQwenTTS:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return _FakeRuntime()
+
+    qwentts_cpp_stub.QwenTTS = FakeQwenTTS
+
+    model = GGMLQwen3TTS.from_pretrained(
+        "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        quant="Q4_K_M",
+        cache_dir=".cache/qwentts",
+        local_files_only=True,
+        library_path="libqwen.so",
+        use_fa=False,
+        clamp_fp16=True,
+    )
+
+    assert isinstance(model, GGMLQwen3TTS)
+    assert captured["args"] == ("Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",)
+    assert captured["kwargs"] == {
+        "quant": "Q4_K_M",
+        "cache_dir": ".cache/qwentts",
+        "local_files_only": True,
+        "library_path": "libqwen.so",
+        "use_fa": False,
+        "clamp_fp16": True,
+    }
+
+
+def test_public_from_pretrained_forwards_qwentts_runtime_flags(monkeypatch):
+    captured = {}
+    sentinel = object()
+
+    def fake_from_pretrained(cls, *args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(
+        GGMLQwen3TTS,
+        "from_pretrained",
+        classmethod(fake_from_pretrained),
+    )
+
+    result = FasterQwen3TTS.from_pretrained(
+        "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        backend="ggml",
+        quant="Q8_0",
+        cache_dir=".cache/qwentts",
+        local_files_only=True,
+        qwentts_library_path="libqwen.so",
+        qwentts_use_fa=False,
+        qwentts_clamp_fp16=True,
+    )
+
+    assert result is sentinel
+    assert captured["args"] == ("Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",)
+    assert captured["kwargs"] == {
+        "quant": "Q8_0",
+        "cache_dir": ".cache/qwentts",
+        "local_files_only": True,
+        "library_path": "libqwen.so",
+        "use_fa": False,
+        "clamp_fp16": True,
+    }
+
+
+def test_public_from_gguf_forwards_qwentts_runtime_flags(monkeypatch):
+    captured = {}
+    sentinel = object()
+
+    def fake_from_gguf(cls, *args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(
+        GGMLQwen3TTS,
+        "from_gguf",
+        classmethod(fake_from_gguf),
+    )
+
+    result = FasterQwen3TTS.from_pretrained(
+        "unused",
+        backend="qwentts",
+        gguf_talker_path="talker.gguf",
+        gguf_codec_path="codec.gguf",
+        qwentts_library_path="libqwen.so",
+        qwentts_use_fa=False,
+        qwentts_clamp_fp16=True,
+    )
+
+    assert result is sentinel
+    assert captured["args"] == ("talker.gguf", "codec.gguf")
+    assert captured["kwargs"] == {
+        "library_path": "libqwen.so",
+        "use_fa": False,
+        "clamp_fp16": True,
+    }
+
+
+def test_cli_parses_qwentts_runtime_flags():
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "--backend",
+            "ggml",
+            "--qwentts-no-fa",
+            "--qwentts-clamp-fp16",
+            "design",
+            "--model",
+            "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign",
+            "--instruct",
+            "warm voice",
+            "--text",
+            "hello",
+            "--output",
+            "out.wav",
+        ]
+    )
+
+    assert args.qwentts_use_fa is False
+    assert args.qwentts_clamp_fp16 is True

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -59,6 +59,9 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     sig_stream = inspect.signature(FasterQwen3TTS.generate_voice_clone_streaming)
     assert "voice_clone_prompt" in sig_clone.parameters
     assert "voice_clone_prompt" in sig_stream.parameters
+    for name in ("ref_spk", "ref_rvq", "ref_spk_emb", "ref_codes"):
+        assert name in sig_clone.parameters
+        assert name in sig_stream.parameters
     assert list(sig_clone.parameters).index("max_new_tokens") == 5
     assert list(sig_stream.parameters).index("max_new_tokens") == 5
     assert list(sig_clone.parameters)[-1] == "voice_clone_prompt"
@@ -67,6 +70,26 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     assert sig_clone.parameters["non_streaming_mode"].default is None
     assert sig_stream.parameters["xvec_only"].default is False
     assert sig_stream.parameters["non_streaming_mode"].default is None
+
+
+def test_torch_backend_rejects_ggml_cached_reference_args():
+    model = _build_dummy_model()
+
+    with pytest.raises(NotImplementedError, match="backend='ggml'"):
+        model.generate_voice_clone(
+            text="hello",
+            language="English",
+            ref_spk="speaker.spk",
+        )
+
+    with pytest.raises(NotImplementedError, match="backend='ggml'"):
+        next(
+            model.generate_voice_clone_streaming(
+                text="hello",
+                language="English",
+                ref_spk="speaker.spk",
+            )
+        )
 
 
 def test_public_api_uses_none_sentinel_for_non_streaming_overrides():


### PR DESCRIPTION
## Summary

- Add an opt-in GGML backend adapter backed by `qwentts-cpp-python`, selectable from the Python API and CLI.
- Add GGUF/lib path support, cached qwentts.cpp reference fields for base voice cloning, and speaker listing for CustomVoice.
- Add GGML docs, TTFA profiling, and a backend comparison benchmark mode.
- Update the demo Space to default to GGML, install the pip package with the GGML extra, use CUDA 12.8, and expose a GGML/Graphs backend toggle.

## Benchmarking

`./benchmark.sh` still runs the existing CUDA-graph benchmarks. Use `./benchmark.sh backends` for the new Torch-vs-GGML comparison, for example:

```bash
MODEL_SIZE=1.7B MODE=custom QUANT=BF16 ./benchmark.sh backends
MODEL_SIZE=0.6B QUANT=BF16 ./benchmark.sh backend-base
```

Local apples-to-apples runs on NVIDIA GB10, BF16, greedy, after warmup:

### 1.7B CustomVoice BF16, speaker aiden

| metric | Torch | GGML | speedup |
| --- | ---: | ---: | ---: |
| load | 25.139 s | 10.260 s | 2.45x |
| warmup | 4.290 s | 1.149 s | 3.73x |
| TTFA chunk 2 | 149.6 ms | 111.4 ms | 1.34x |
| TTFA chunk 4 | 238.9 ms | 173.5 ms | 1.38x |
| TTFA chunk 8 | 420.4 ms | 289.5 ms | 1.45x |
| TTFA chunk 16 | 793.8 ms | 540.9 ms | 1.47x |
| buffered throughput | 47.39 ms/frame | 32.01 ms/frame | 1.48x |
| streaming chunk 8 | 49.73 ms/frame | 34.39 ms/frame | 1.45x |

### 0.6B Base BF16, raw reference audio, cached after warmup

Current rerun with `qwentts-cpp-python`/qwentts.cpp ABI v2 cache path. The warmup generation populates the raw reference cache; TTFA rows represent warm server requests using the cached voice reference.

| metric | Torch | GGML | speedup |
| --- | ---: | ---: | ---: |
| load | 11.807 s | 3.123 s | 3.78x |
| warmup | 5.039 s | 1.108 s | 4.55x |
| TTFA chunk 2 | 197.0 ms | 91.4 ms | 2.16x |
| TTFA chunk 4 | 263.6 ms | 125.5 ms | 2.10x |
| TTFA chunk 8 | 392.1 ms | 202.1 ms | 1.94x |
| TTFA chunk 16 | 655.6 ms | 359.2 ms | 1.83x |
| buffered throughput | 34.4 ms/frame | 20.3 ms/frame | 1.69x |
| streaming chunk 8 | 40.7 ms/frame | 22.7 ms/frame | 1.79x |

## Validation

- `.venv/bin/python -m pytest -q tests/test_ggml_backend.py tests/test_voice_clone_prompt_api.py tests/test_sample_rate.py tests/test_sampling.py`
- `.venv/bin/python -m py_compile demo/server.py faster_qwen3_tts/ggml_backend.py faster_qwen3_tts/model.py`
- `.venv/bin/python demo/server.py --help`
- `.venv/bin/python benchmarks/backend_compare.py --backend both --mode base --model-size 0.6B --quant BF16 --greedy --ttfa-runs 3 --throughput-runs 1 --chunk-sizes 2,4,8,16 --max-new-tokens 128 --local-files-only --json-output /tmp/backend_compare_0_6b_base_current.json`