### PR TITLE
Release 0.3.0

### DIFF
--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -4,5 +4,5 @@ faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 from .model import FasterQwen3TTS
 from .ggml_backend import GGMLQwen3TTS
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 __all__ = ["FasterQwen3TTS", "GGMLQwen3TTS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["faster_qwen3_tts*"]
 
 [project]
 name = "faster-qwen3-tts"
-version = "0.2.6"
+version = "0.3.0"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump `faster-qwen3-tts` from `0.2.6` to `0.3.0` after merging the GGML backend integration.

## Validation

- `python -m pip index versions faster-qwen3-tts` confirms PyPI latest is `0.2.6`, so `0.3.0` is available.
- `.venv/bin/python -m pytest -q tests/test_ggml_backend.py tests/test_voice_clone_prompt_api.py tests/test_sample_rate.py tests/test_sampling.py`
- `.venv/bin/python -m py_compile demo/server.py faster_qwen3_tts/ggml_backend.py faster_qwen3_tts/model.py faster_qwen3_tts/cli.py`
- `.venv/bin/python -m build --sdist --wheel --outdir /tmp/faster-qwen3-tts-release-0.3.0.AaITQQ`
- `.venv/bin/python -m twine check /tmp/faster-qwen3-tts-release-0.3.0.AaITQQ/*`

Built artifacts:

- `/tmp/faster-qwen3-tts-release-0.3.0.AaITQQ/faster_qwen3_tts-0.3.0-py3-none-any.whl`
- `/tmp/faster-qwen3-tts-release-0.3.0.AaITQQ/faster_qwen3_tts-0.3.0.tar.gz`
