### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "latest"
+          enable-cache: false
+      - name: Build distributions
+        run: uv build
+      - name: Check package metadata
+        run: uvx twine check --strict dist/*
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/faster-qwen3-tts/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary

Add a PyPI publish workflow matching the tag-driven release flow used by `speech-to-speech`.

The workflow:

- runs on pushed `v*` tags and manual dispatch
- builds wheel and sdist with `uv build`
- validates artifacts with `twine check --strict`
- uploads the build artifact
- publishes to PyPI from the `pypi` environment using Trusted Publishing / OIDC

## After merge

1. Configure PyPI Trusted Publisher for this project if it is not already configured:
   - repository: `andimarafioti/faster-qwen3-tts`
   - workflow: `.github/workflows/publish.yml`
   - environment: `pypi`
2. Pull `main`.
3. Create and push the release tag:
   ```bash
   git tag -a v0.3.0 -m "Release v0.3.0"
   git push origin v0.3.0
   ```
4. Watch the `Publish` workflow.
5. Verify `0.3.0` on PyPI.

## Validation

- `uv build --out-dir /tmp/faster-qwen3-tts-uv-build.IIDSo4`
- `uvx twine check --strict /tmp/faster-qwen3-tts-uv-build.IIDSo4/*`
- `git diff --check`
