### PR TITLE
Use PyPI package in demo Space

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -14,7 +14,6 @@ ENV TORCHINDUCTOR_CACHE_DIR=/tmp/torch_inductor
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
-ARG FASTER_QWEN3_TTS_REF=main
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
@@ -29,9 +28,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/b
     && uv venv --python 3.10 --seed "$VIRTUAL_ENV" \
     && "$VIRTUAL_ENV/bin/python" -m pip install --upgrade pip \
     && "$VIRTUAL_ENV/bin/python" -m pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio \
-    && "$VIRTUAL_ENV/bin/python" -m pip install "qwentts-cpp-python==0.3.0+cu128" \
-        -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128 \
-    && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt "faster-qwen3-tts[demo] @ git+https://github.com/andimarafioti/faster-qwen3-tts.git@${FASTER_QWEN3_TTS_REF}" \
+    && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt "faster-qwen3-tts[demo,ggml]==0.3.0" \
     && "$VIRTUAL_ENV/bin/python" -m pip install -c constraints.txt -r requirements.txt
 
 EXPOSE 7860

--- a/demo/README.md
+++ b/demo/README.md
@@ -25,9 +25,7 @@ This Space hosts the demo UI for **faster-qwen3-tts** with streaming audio, TTFA
 
 ```bash
 pip install --index-url https://download.pytorch.org/whl/cu128 torch torchaudio
-pip install "qwentts-cpp-python==0.3.0+cu128" \
-  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
-pip install "faster-qwen3-tts[demo]" nano-parakeet
+pip install "faster-qwen3-tts[demo,ggml]==0.3.0" nano-parakeet
 python server.py --backend ggml --model Qwen/Qwen3-TTS-12Hz-0.6B-Base
 # open http://localhost:7860
 ```


### PR DESCRIPTION
## Summary

- Install `faster-qwen3-tts[demo,ggml]==0.3.0` from PyPI in the Space Docker image.
- Remove the GitHub ref install and the manual `qwentts-cpp-python` HF wheel install from the Docker build.
- Update the Space README local install snippet to use the released PyPI package path.

## Why

The hosted demo should exercise the same released package that users install with pip, while keeping the default GGML backend on CUDA 12.8.

## Validation

- Ran a fresh-venv pip dry run with `-c demo/constraints.txt "faster-qwen3-tts[demo,ggml]==0.3.0" -r demo/requirements.txt`.
- Resolution selected `faster-qwen3-tts==0.3.0` and `qwentts-cpp-python==0.3.0` from PyPI.
