### PR TITLE
Expose decoder context for CustomVoice streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ Smaller chunks = lower latency but more decode overhead. `chunk_size=2` is the s
 
 The CUDA graphs are unchanged — both predictor and talker graphs are replayed per step. The streaming generator yields codec ID chunks every `chunk_size` steps, and the model wrapper decodes each chunk to audio using a sliding window with 25-frame left context (matching the upstream codec's `chunked_decode` pattern) to avoid boundary artifacts.
 
+`generate_custom_voice_streaming()` accepts `decoder_context_frames` to tune
+that left-context window; its default remains 25 for backward compatibility.
+
 The Python streaming methods are pull-based generators: they prepare the next chunk when the caller requests it. For realtime local playback, use a queue-backed player such as `StreamPlayer`; blocking after each yielded chunk prevents generation and playback from overlapping.
 
 ## Voice Cloning Quality

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -1227,9 +1227,16 @@ class FasterQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        decoder_context_frames: int = 25,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         if self.model.model.tts_model_type != "custom_voice":
             raise ValueError("Loaded model does not support custom voice generation")
+        if (
+            isinstance(decoder_context_frames, bool)
+            or not isinstance(decoder_context_frames, int)
+            or decoder_context_frames < 1
+        ):
+            raise ValueError("decoder_context_frames must be a positive integer")
 
         self.model._validate_languages([language])
         self.model._validate_speakers([speaker])
@@ -1254,7 +1261,7 @@ class FasterQwen3TTS:
 
         speech_tokenizer = m.speech_tokenizer
 
-        context_frames = 25
+        context_frames = decoder_context_frames
         min_calibration_frames = max(context_frames, chunk_size)
         all_codes = []
         prev_audio_len = 0

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -104,6 +104,76 @@ def test_public_api_uses_none_sentinel_for_non_streaming_overrides():
     assert sig_design_stream.parameters["non_streaming_mode"].default is None
 
 
+def test_custom_voice_streaming_exposes_decoder_context_frames():
+    signature = inspect.signature(FasterQwen3TTS.generate_custom_voice_streaming)
+
+    assert signature.parameters["decoder_context_frames"].default == 25
+
+
+@pytest.mark.parametrize("invalid_value", [True, 0, -1, 25.0])
+def test_custom_voice_streaming_rejects_invalid_decoder_context_frames(invalid_value):
+    model = _build_dummy_model()
+    model.model.model.tts_model_type = "custom_voice"
+
+    with pytest.raises(ValueError, match="positive integer"):
+        next(
+            model.generate_custom_voice_streaming(
+                text="hello",
+                speaker="speaker_a",
+                language="English",
+                decoder_context_frames=invalid_value,
+            )
+        )
+
+
+def test_custom_voice_streaming_uses_requested_decoder_context(monkeypatch):
+    import faster_qwen3_tts.streaming as streaming
+
+    model = _build_dummy_model()
+    model.model.model.tts_model_type = "custom_voice"
+    decoded_frame_counts = []
+
+    class RecordingSpeechTokenizer:
+        def decode(self, payload):
+            frame_count = int(payload["audio_codes"].shape[1])
+            decoded_frame_counts.append(frame_count)
+            return [torch.zeros(frame_count * 2, dtype=torch.float32)], 24_000
+
+    prepared_model = types.SimpleNamespace(speech_tokenizer=RecordingSpeechTokenizer())
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation_custom",
+        lambda **_kwargs: (
+            prepared_model,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        ),
+    )
+
+    def fake_stream(**_kwargs):
+        for _ in range(10):
+            yield torch.zeros(12, 16, dtype=torch.long), {}
+
+    monkeypatch.setattr(streaming, "fast_generate_streaming", fake_stream)
+
+    chunks = list(
+        model.generate_custom_voice_streaming(
+            text="hello",
+            speaker="speaker_a",
+            language="English",
+            chunk_size=12,
+            decoder_context_frames=100,
+        )
+    )
+
+    assert len(chunks) == 10
+    assert decoded_frame_counts == [12, 24, 36, 48, 60, 72, 84, 96, 108, 112]
+
+
 @pytest.mark.parametrize(
     ("method_name", "kwargs", "expected_default"),
     [


### PR DESCRIPTION
## Summary

This PR exposes the CustomVoice streaming decoder’s left-context window through a new `decoder_context_frames` argument on `generate_custom_voice_streaming()`.

The default remains `25`, preserving the current behaviour and performance profile for existing callers. The option is intentionally scoped to the CustomVoice streaming path that was tested.

## Motivation

The streaming decoder currently uses a fixed 25-frame context when reconstructing successive audio chunks. In a downstream real-time integration, an identical-token A/B comparison isolated intermittent voice discontinuity to this decode window. Using 100 frames produced clean continuity across six consecutive English/Japanese trials spanning short, medium, and long responses.

Because a larger window requires additional decoder work, changing the global default may not suit every use case. Exposing the existing value allows callers to choose the continuity/performance trade-off they need while maintaining backward compatibility.

## Changes

- Add `decoder_context_frames: int = 25` to `generate_custom_voice_streaming()`
- Reject booleans, non-integers, and values below 1 with a clear `ValueError`
- Use the requested value for initial calibration and the rolling decoder context
- Document the option in the README
- Cover the default, validation, and a 100-frame decode window in tests

## Validation

- Focused test file (`tests/test_voice_clone_prompt_api.py`): 35 tests passed
- Six consecutive English/Japanese streaming trials completed without distracting degradation, missing or repeated speech, or recognizable voice drift

Thanks for maintaining this project. I’m happy to adjust the API naming or scope if you would prefer a different shape.