### PR TITLE
Expose public backend warmup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ audio_list, sr = model.generate_voice_clone(
 )
 ```
 
+Call `model.warmup(prefill_len=100)` to prepare a model explicitly before
+serving requests. It captures CUDA graphs for the Torch backend and is a safe
+no-op for GGML; normal generation also performs any required lazy preparation.
+
 For local speaker playback from a repo checkout with the example helper:
 
 ```bash

--- a/demo/server.py
+++ b/demo/server.py
@@ -752,7 +752,7 @@ def _load_tts_model(model_id: str, backend: str, *, quant: str | None = None):
     model = FasterQwen3TTS.from_pretrained(model_id, **kwargs)
     if backend == "torch":
         print("Capturing CUDA graphs…")
-        model._warmup(prefill_len=100)
+        model.warmup(prefill_len=100)
         _prime_preset_voice_cache(model)
         print("CUDA graphs captured — model ready.")
     else:

--- a/examples/generate_with_embedding.py
+++ b/examples/generate_with_embedding.py
@@ -76,7 +76,7 @@ def main():
     print(f"Prefill length: {prefill_len} tokens")
 
     # Warmup + capture CUDA graphs (one-time)
-    model._warmup(prefill_len)
+    model.warmup(prefill_len)
 
     # Warmup
     talker = model.model.model.talker

--- a/faster_qwen3_tts/ggml_backend.py
+++ b/faster_qwen3_tts/ggml_backend.py
@@ -111,6 +111,15 @@ class GGMLQwen3TTS:
             return []
         return list(self.runtime.speaker_names())
 
+    def warmup(self, prefill_len: int = 100) -> None:
+        """Warm up the backend before generation.
+
+        qwentts.cpp has no separate CUDA-graph capture step, so this is a
+        deliberate no-op. ``prefill_len`` is accepted for API compatibility
+        with the Torch backend.
+        """
+        return None
+
     @classmethod
     def from_gguf(
         cls,

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -143,7 +143,8 @@ class FasterQwen3TTS:
                 `.spk` / `.rvq` references extracted from raw reference audio.
             
         Returns:
-            FasterQwen3TTS instance
+            A backend-specific model implementing the public generation and
+            warmup APIs.
         """
         if backend not in ("torch", "ggml", "qwentts"):
             raise ValueError(f"Unsupported backend {backend!r}. Expected 'torch', 'ggml', or 'qwentts'.")
@@ -235,8 +236,12 @@ class FasterQwen3TTS:
             max_seq_len=max_seq_len,
         )
     
-    def _warmup(self, prefill_len: int):
-        """Warm up and capture CUDA graphs with given prefill length."""
+    def warmup(self, prefill_len: int = 100) -> None:
+        """Warm up the backend before generation.
+
+        For the Torch backend, this captures the predictor and talker CUDA
+        graphs using ``prefill_len`` as the simulated prompt length.
+        """
         if self._warmed_up:
             return
             
@@ -245,6 +250,10 @@ class FasterQwen3TTS:
         self.talker_graph.capture(prefill_len=prefill_len, num_warmup=3)
         self._warmed_up = True
         logger.info("CUDA graphs captured and ready")
+
+    def _warmup(self, prefill_len: int) -> None:
+        """Compatibility alias for the former private warmup entry point."""
+        self.warmup(prefill_len=prefill_len)
     
     def generate(
         self,
@@ -520,7 +529,7 @@ class FasterQwen3TTS:
         )
 
         if not self._warmed_up:
-            self._warmup(tie.shape[1])
+            self.warmup(tie.shape[1])
 
         talker = m.talker
         config = m.config.talker_config
@@ -563,7 +572,7 @@ class FasterQwen3TTS:
         )
 
         if not self._warmed_up:
-            self._warmup(tie.shape[1])
+            self.warmup(tie.shape[1])
 
         talker = m.talker
         config = m.config.talker_config

--- a/tests/test_e2e_parity.py
+++ b/tests/test_e2e_parity.py
@@ -212,7 +212,7 @@ def parity_fixture():
         fast.predictor_graph.top_k = 0
         fast.predictor_graph.top_p = 1.0
         fast.predictor_graph.temperature = 1.0
-        fast._warmup(tie.shape[1])
+        fast.warmup(tie.shape[1])
 
     data = dict(
         base=base,
@@ -291,7 +291,7 @@ def parity_fixture_fp32():
         fast.predictor_graph.top_k = 0
         fast.predictor_graph.top_p = 1.0
         fast.predictor_graph.temperature = 1.0
-        fast._warmup(tie.shape[1])
+        fast.warmup(tie.shape[1])
 
     data = dict(
         base=base,
@@ -537,7 +537,7 @@ class TestFP32Parity:
             fast.predictor_graph.top_k = 0
             fast.predictor_graph.top_p = 1.0
             fast.predictor_graph.temperature = 1.0
-            fast._warmup(tie.shape[1])
+            fast.warmup(tie.shape[1])
 
         fast.model.model.talker.rope_deltas = None
         fast_codes, _ = fast_generate(
@@ -823,7 +823,7 @@ class TestBF16Parity:
             fast.predictor_graph.top_k = 0
             fast.predictor_graph.top_p = 1.0
             fast.predictor_graph.temperature = 1.0
-            fast._warmup(tie.shape[1])
+            fast.warmup(tie.shape[1])
 
         fast.model.model.talker.rope_deltas = None
         fast_codes, _ = fast_generate(

--- a/tests/test_ggml_backend.py
+++ b/tests/test_ggml_backend.py
@@ -304,6 +304,14 @@ def test_ggml_speaker_listing_uses_runtime():
     assert model.get_supported_speakers() == ["aiden", "vivian"]
 
 
+def test_ggml_public_warmup_is_a_no_op():
+    runtime = _FakeRuntime()
+    model = GGMLQwen3TTS(runtime)
+
+    assert model.warmup(prefill_len=42) is None
+    assert runtime.calls == []
+
+
 def test_adapter_from_pretrained_forwards_qwentts_runtime_flags(monkeypatch, qwentts_cpp_stub):
     captured = {}
 

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -44,7 +44,7 @@ def _build_dummy_model():
         torch.zeros(1, 1, 4, dtype=torch.float32),
         torch.zeros(1, 1, 4, dtype=torch.float32),
     )
-    model._warmup = lambda _prefill_len: setattr(model, "_warmed_up", True)
+    model.warmup = lambda _prefill_len: setattr(model, "_warmed_up", True)
     return model
 
 
@@ -70,6 +70,47 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     assert sig_clone.parameters["non_streaming_mode"].default is None
     assert sig_stream.parameters["xvec_only"].default is False
     assert sig_stream.parameters["non_streaming_mode"].default is None
+
+
+def test_public_warmup_captures_torch_graphs_once():
+    predictor_calls = []
+    talker_calls = []
+    predictor_graph = types.SimpleNamespace(
+        capture=lambda **kwargs: predictor_calls.append(kwargs),
+    )
+    talker_graph = types.SimpleNamespace(
+        capture=lambda **kwargs: talker_calls.append(kwargs),
+    )
+    base = types.SimpleNamespace(sample_rate=24000)
+    model = FasterQwen3TTS(
+        base,
+        predictor_graph,
+        talker_graph,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    model.warmup(prefill_len=42)
+    model.warmup(prefill_len=99)
+
+    assert predictor_calls == [{"num_warmup": 3}]
+    assert talker_calls == [{"prefill_len": 42, "num_warmup": 3}]
+
+
+def test_private_warmup_alias_uses_public_api(monkeypatch):
+    model = FasterQwen3TTS(
+        types.SimpleNamespace(sample_rate=24000),
+        _dummy_graph(),
+        _dummy_graph(),
+        device="cpu",
+        dtype=torch.float32,
+    )
+    calls = []
+    monkeypatch.setattr(model, "warmup", lambda *, prefill_len: calls.append(prefill_len))
+
+    model._warmup(37)
+
+    assert calls == [37]
 
 
 def test_torch_backend_rejects_ggml_cached_reference_args():


### PR DESCRIPTION
## Summary

- expose a public `warmup(prefill_len=100)` method for both supported backends
- keep the former Torch `_warmup()` method as a compatibility alias
- make GGML warmup an explicit no-op because qwentts.cpp has no separate CUDA-graph capture step
- migrate internal, demo, example, and parity-test callers to the public API
- document and test the shared backend contract

## Why

The `speech-to-speech` Qwen3-TTS integration currently calls the private Torch `_warmup()` method even when `FasterQwen3TTS.from_pretrained(..., backend="ggml")` returns `GGMLQwen3TTS`. That produces a caught `AttributeError` and a misleading CUDA graph warning during startup ([huggingface/speech-to-speech#354](https://github.com/huggingface/speech-to-speech/issues/354)).

A shared public method keeps backend dispatch inside this package. Torch captures its graphs once, while GGML safely returns without doing additional work; consumers can then use the same supported API for either backend.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest -q`
  - 78 passed, 1 skipped
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/test_ggml_backend.py tests/test_voice_clone_prompt_api.py`
  - 51 passed
- `git diff --check`
