### PR TITLE
Release 0.3.1

### DIFF
--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -4,5 +4,5 @@ faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 from .model import FasterQwen3TTS
 from .ggml_backend import GGMLQwen3TTS
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __all__ = ["FasterQwen3TTS", "GGMLQwen3TTS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["faster_qwen3_tts*"]
 
 [project]
 name = "faster-qwen3-tts"
-version = "0.3.0"
+version = "0.3.1"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump `faster-qwen3-tts` from `0.3.0` to `0.3.1` after merging the public backend warmup API.

This patch release exposes `model.warmup()` consistently across Torch and GGML so integrations can prepare either backend without calling the private Torch-only `_warmup()` method.

## Validation

- PyPI confirms `0.3.0` is currently the latest release, so `0.3.1` is available.
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/test_ggml_backend.py tests/test_voice_clone_prompt_api.py tests/test_sample_rate.py tests/test_sampling.py` — 59 passed
- `PYTHONPATH=. .venv/bin/python -m py_compile demo/server.py faster_qwen3_tts/ggml_backend.py faster_qwen3_tts/model.py faster_qwen3_tts/cli.py`
- `uv build` produced the `0.3.1` wheel and source distribution.
- `uvx twine check --strict` passed for both distributions.
- Wheel metadata reports `Version: 0.3.1`.
- `git diff --check`
