### PR TITLE
feat: should_stop cancellation hook for streaming generation

### DIFF
--- a/faster_qwen3_tts/ggml_backend.py
+++ b/faster_qwen3_tts/ggml_backend.py
@@ -231,6 +231,7 @@ class GGMLQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        should_stop: Optional[Callable[[], bool]] = None,
         xvec_only: bool = False,
         non_streaming_mode: Optional[bool] = None,
         append_silence: bool = True,
@@ -261,6 +262,7 @@ class GGMLQwen3TTS:
             ref_codes=ref_codes,
         )
         yield from self._stream_runtime(
+            should_stop=should_stop,
             text=text,
             lang=language,
             **ref_kwargs,
@@ -544,10 +546,12 @@ class GGMLQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        should_stop: Optional[Callable[[], bool]] = None,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         _warn_non_prefill_text_mode(non_streaming_mode)
         adapter_start = time.perf_counter()
         yield from self._stream_runtime(
+            should_stop=should_stop,
             text=text,
             lang=language,
             speaker=speaker,
@@ -604,10 +608,12 @@ class GGMLQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        should_stop: Optional[Callable[[], bool]] = None,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         _warn_non_prefill_text_mode(non_streaming_mode)
         adapter_start = time.perf_counter()
         yield from self._stream_runtime(
+            should_stop=should_stop,
             text=text,
             lang=language,
             instruct=instruct,
@@ -627,6 +633,7 @@ class GGMLQwen3TTS:
         chunk_size: int,
         adapter_prepare_ms: float = 0.0,
         adapter_profile: Optional[dict] = None,
+        should_stop: Optional[Callable[[], bool]] = None,
         **kwargs,
     ):
         chunk_sec = max(1, int(chunk_size)) / _QWEN_FRAME_RATE
@@ -635,6 +642,8 @@ class GGMLQwen3TTS:
         for idx, (chunk, sr) in enumerate(
             self.runtime.stream(codec_chunk_sec=chunk_sec, **kwargs)
         ):
+            if should_stop is not None and should_stop():
+                break  # caller gone — stop consuming the runtime stream (chunk granularity)
             now = time.perf_counter()
             native_profile = getattr(self.runtime, "last_stream_profile", None)
             yield chunk, sr, {

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -6,7 +6,7 @@ CUDA graphs for 6-10x speedup.
 """
 import logging
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 import soundfile as sf
@@ -959,6 +959,7 @@ class FasterQwen3TTS:
         non_streaming_mode: Optional[bool] = None,
         append_silence: bool = True,
         parity_mode: bool = False,
+        should_stop: Optional[Callable[[], bool]] = None,
         instruct: Optional[str] = None,
         ref_spk: Optional[Union[str, Path]] = None,
         ref_rvq: Optional[Union[str, Path]] = None,
@@ -993,6 +994,9 @@ class FasterQwen3TTS:
                 (False, step-by-step text feeding during decode). Set to True to
                 prefill the full target text before streaming decode.
             parity_mode: When True, disables CUDA graphs and uses dynamic cache streaming.
+            should_stop: Optional callable polled at each chunk boundary BEFORE the
+                (expensive) codec decode; return True to abort generation early
+                (e.g. client disconnected). Connected-client behavior is unchanged.
             voice_clone_prompt: Optional precomputed voice clone prompt dict. When provided,
                 `xvec_only` is ignored and prompt extraction from `ref_audio` is skipped.
                 This path supports x-vector-only prompts (`ref_spk_embedding` only)
@@ -1062,12 +1066,15 @@ class FasterQwen3TTS:
             do_sample=do_sample,
             repetition_penalty=repetition_penalty,
             chunk_size=chunk_size,
+            should_stop=should_stop,
         )
         if not parity_mode:
             stream_kwargs["predictor_graph"] = self.predictor_graph
             stream_kwargs["talker_graph"] = self.talker_graph
 
         for codec_chunk, timing in stream_fn(**stream_kwargs):
+            if should_stop is not None and should_stop():
+                break  # caller gone — skip the expensive decode of a chunk nobody consumes
             all_codes.append(codec_chunk)
             n_new = codec_chunk.shape[0]
             all_flat = torch.cat(all_codes, dim=0)

--- a/faster_qwen3_tts/streaming.py
+++ b/faster_qwen3_tts/streaming.py
@@ -6,7 +6,7 @@ Yields codec ID chunks during generation instead of collecting all at once.
 CUDA graph usage is identical to non-streaming — same per-step performance.
 """
 import time
-from typing import Generator, Tuple
+from typing import Callable, Generator, Optional, Tuple
 
 import torch
 
@@ -33,6 +33,7 @@ def fast_generate_streaming(
     do_sample: bool = True,
     repetition_penalty: float = 1.05,
     chunk_size: int = 12,
+    should_stop: Optional[Callable[[], bool]] = None,
 ) -> Generator[Tuple[torch.Tensor, dict], None, None]:
     """
     Streaming autoregressive generation with CUDA-graphed predictor and talker.
@@ -40,6 +41,9 @@ def fast_generate_streaming(
     Yields (codec_chunk, timing_info) tuples every chunk_size steps.
     codec_chunk: [chunk_steps, 16] tensor of codec IDs.
     The final chunk may be shorter than chunk_size.
+
+        should_stop: Optional callable polled once per decode step (~tens of ms);
+            return True to abort generation early (e.g. client disconnected).
     """
     eos_id = config.codec_eos_token_id
     vocab_size = config.vocab_size
@@ -104,6 +108,8 @@ def fast_generate_streaming(
     chunk_start = time.time()
 
     for step_idx in range(max_new_tokens):
+        if should_stop is not None and should_stop():
+            break  # caller gone — abort at step granularity, not chunk granularity
         if token.item() == eos_id:
             break
 
@@ -204,11 +210,15 @@ def parity_generate_streaming(
     do_sample: bool = True,
     repetition_penalty: float = 1.05,
     chunk_size: int = 12,
+    should_stop: Optional[Callable[[], bool]] = None,
 ) -> Generator[Tuple[torch.Tensor, dict], None, None]:
     """
     Streaming generation without CUDA graphs (dynamic cache).
 
     Yields (codec_chunk, timing_info) tuples every chunk_size steps.
+
+        should_stop: Optional callable polled once per decode step (~tens of ms);
+            return True to abort generation early (e.g. client disconnected).
     """
     # NOTE: This function intentionally mirrors fast_generate_streaming. The core
     # decode loop is duplicated so we can swap CUDA graphs/static cache for the
@@ -270,6 +280,8 @@ def parity_generate_streaming(
     chunk_start = time.time()
 
     for _ in range(max_new_tokens):
+        if should_stop is not None and should_stop():
+            break  # caller gone — abort at step granularity, not chunk granularity
         if token.item() == eos_id:
             break
 


### PR DESCRIPTION
## Problem

A streaming caller that disconnects mid-clip — a voice UI on barge-in, or any harness that only needs time-to-first-audio — leaves the engine doing work nobody will consume:

- **torch path**: `fast_generate_streaming` generates the next chunk's codec tokens, and `generate_voice_clone_streaming` then runs the hybrid decode (with the full ICL reference prepended during the early accumulated-decode phase) before control ever returns to the caller's loop, which is the first place iteration can stop.
- **ggml path**: `_stream_runtime` keeps consuming the runtime stream.

Measured on a GB10 (26.4 s ICL ref, `chunk_size=8`, CUDA-graph fast path): **750–1000 ms of orphaned engine time per disconnect**. On a shared GPU that residual serializes behind the next request — a co-located whisper.cpp STT call stretched 205 → 531 ms when issued right after a disconnect.

## Change

Optional `should_stop: Callable[[], bool] = None` on the streaming entry points:

- **torch**: polled once per decode step in `fast_generate_streaming` / `parity_generate_streaming` (~tens of ms granularity) and again before each chunk's codec decode in `generate_voice_clone_streaming` — a disconnected caller pays at most a few decode steps and never a wasted vocoder decode. The same measurement drops to **62–109 ms**.
- **ggml**: polled per chunk in `_stream_runtime` before consuming the next runtime chunk; plumbed through `generate_voice_clone_streaming`, `generate_custom_voice_streaming`, `generate_voice_design_streaming`.

`None` (default) is byte-identical behavior. Connected-but-slow callers are unaffected — this only lets a caller that *knows* its consumer is gone (e.g. an HTTP server whose client socket closed, surfaced via `request.is_disconnected()`) release the engine promptly.

## Usage sketch

```python
stop = threading.Event()  # set when the HTTP client disconnects
for chunk, sr, timing in model.generate_voice_clone_streaming(
    text=text, language="English", ref_audio=ref, ref_text=ref_text,
    chunk_size=8, should_stop=stop.is_set,
):
    ...
```

Running in production since 2026-07-15 on the torch path (GB10 / sm_121a); the GGML plumbing follows the same shape and compiles clean, but I don't have a qwentts.cpp setup to latency-profile — happy to adjust if you'd rather scope this PR to the torch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)