### PR TITLE
Prepare release 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,18 @@ faster-qwen3-tts --backend ggml --quant BF16 design \
   --output out.wav
 ```
 
-The extra installs `qwentts-cpp-python>=0.3.0` from PyPI. That default wheel is
+The extra installs `qwentts-cpp-python>=0.3.1` from PyPI. That default wheel is
 CUDA 12.8. For CUDA 13 / DGX Spark, CUDA 12.4 targets, or Ubuntu 22.04 / older
 Linux hosts that need a `manylinux_2_35` wheel, install the matching wrapper
 wheel from the Hugging Face wheelhouse before installing the extra:
 
 ```bash
 # Ubuntu 22.04 / older Linux with CUDA 12.8
-pip install "qwentts-cpp-python==0.3.0+cu128" \
+pip install "qwentts-cpp-python==0.3.1+cu128" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
 
 # CUDA 13 / DGX Spark
-pip install "qwentts-cpp-python==0.3.0+cu130" \
+pip install "qwentts-cpp-python==0.3.1+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 
 pip install "faster-qwen3-tts[ggml]"

--- a/docs/ggml-backend.md
+++ b/docs/ggml-backend.md
@@ -38,17 +38,17 @@ the `manylinux_2_35` CUDA 12.8 build.
 
 ```bash
 # Ubuntu 22.04 / older Linux with CUDA 12.8
-pip install "qwentts-cpp-python==0.3.0+cu128" \
+pip install "qwentts-cpp-python==0.3.1+cu128" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
 
 # CUDA 13 / DGX Spark
-pip install "qwentts-cpp-python==0.3.0+cu130" \
+pip install "qwentts-cpp-python==0.3.1+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 
 pip install "faster-qwen3-tts[ggml]"
 ```
 
-The same wheel index also has `0.3.0+cu124`, `0.3.0+cu128`, and `0.3.0+cpu`
+The same wheel index also has `0.3.1+cu124`, `0.3.1+cu128`, and `0.3.1+cpu`
 variants.
 
 For local wrapper development, clone the wrapper repo beside this checkout and
@@ -181,28 +181,28 @@ The legacy CUDA-graph-only benchmarks still run with `./benchmark.sh`.
 
 ## Wheel Distribution
 
-`qwentts-cpp-python==0.3.0` is published on PyPI. The PyPI package is the
+`qwentts-cpp-python==0.3.1` is published on PyPI. The PyPI package is the
 default CUDA 12.8 wheel used by `pip install "faster-qwen3-tts[ggml]"`.
 Additional local-version wheels are hosted on Hugging Face Hub:
 
 ```bash
-pip install "qwentts-cpp-python==0.3.0+cpu" \
+pip install "qwentts-cpp-python==0.3.1+cpu" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cpu
 
-pip install "qwentts-cpp-python==0.3.0+cu124" \
+pip install "qwentts-cpp-python==0.3.1+cu124" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu124
 
-pip install "qwentts-cpp-python==0.3.0+cu128" \
+pip install "qwentts-cpp-python==0.3.1+cu128" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu128
 
-pip install "qwentts-cpp-python==0.3.0+cu130" \
+pip install "qwentts-cpp-python==0.3.1+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 ```
 
 Hugging Face file hosting is used as a `--find-links` wheelhouse rather than a
 PyTorch-style package index. For CUDA 13 / DGX Spark, install the `+cu130`
 wheel before installing `faster-qwen3-tts[ggml]`. For Ubuntu 22.04 / older
-Linux hosts, install `0.3.0+cu128` from the Hugging Face wheelhouse so pip can
+Linux hosts, install `0.3.1+cu128` from the Hugging Face wheelhouse so pip can
 select the `manylinux_2_35` CUDA 12.8 wheel.
 
 For publishing new wrapper wheels, use the manual GitHub Actions workflow:

--- a/faster_qwen3_tts/__init__.py
+++ b/faster_qwen3_tts/__init__.py
@@ -4,5 +4,5 @@ faster-qwen3-tts: Real-time Qwen3-TTS inference using CUDA graphs
 from .model import FasterQwen3TTS
 from .ggml_backend import GGMLQwen3TTS
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __all__ = ["FasterQwen3TTS", "GGMLQwen3TTS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["faster_qwen3_tts*"]
 
 [project]
 name = "faster-qwen3-tts"
-version = "0.3.1"
+version = "0.3.2"
 description = "Real-time Qwen3-TTS inference using manual CUDA graph capture"
 readme = "README.md"
 license = "MIT"
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ggml = [
-    "qwentts-cpp-python>=0.3.0",
+    "qwentts-cpp-python>=0.3.1",
 ]
 demo = [
     "fastapi>=0.100.0",


### PR DESCRIPTION
## Summary

- bump `faster-qwen3-tts` from `0.3.1` to `0.3.2`
- require `qwentts-cpp-python>=0.3.1` for the optional GGML backend
- update README and GGML backend installation examples to the `0.3.1` wrapper release

## Why

`qwentts-cpp-python` 0.3.1 packages the latest pinned qwentts.cpp revision.
This release makes the updated native wrapper the minimum installed by the
`ggml` extra and keeps the backend-specific wheel instructions aligned.

## Validation

- confirmed `faster-qwen3-tts` 0.3.2 is not currently published on PyPI
- confirmed project and package versions both resolve to `0.3.2`
- confirmed the `ggml` extra resolves to `qwentts-cpp-python>=0.3.1`
- `78 passed, 1 skipped`
- `git diff --check`

After merge, publishing should use an annotated `v0.3.2` tag.
