### PR TITLE
Expose decoder context for voice clone streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ The default now matches upstream Qwen3-TTS: ICL mode with the reference audio in
 
 The 12 Hz codec uses a causal `chunked_decode`: each frame is reconstructed using prior frames as acoustic context. In ICL mode the reference audio codec tokens are prepended to the generated tokens before decoding, then the reference portion is trimmed from the output. Without this, the codec decoder starts cold with no voice context — the model generates the right tokens but they get reconstructed in the wrong voice. This is handled automatically.
 
+`generate_voice_clone_streaming()` accepts `decoder_context_frames` to tune the left-context window used for successive audio chunks. The default remains `25` for backward compatibility; callers can evaluate larger values when continuity is more important than decoder cost.
+
 ### Text input streaming vs Non-streaming quality
 
 The original Qwen3TTS implementation supports two mode of generation. It either takes the full input text and prepares the utterance, or it feeds the text progressively. This is the `non_streaming_mode` parameter in the generation methods. The name is maintained from the Qwen3TTS implementation, but I understand it might bring some headaches since here we also have general audio output streaming.

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -974,6 +974,7 @@ class FasterQwen3TTS:
         ref_spk_emb: Optional[np.ndarray] = None,
         ref_codes: Optional[np.ndarray] = None,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[Any]]] = None,
+        decoder_context_frames: int = 25,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         """
         Stream voice-cloned speech generation, yielding audio chunks.
@@ -1007,6 +1008,9 @@ class FasterQwen3TTS:
                 This path supports x-vector-only prompts (`ref_spk_embedding` only)
                 and ICL prompts (`ref_spk_embedding` + `ref_code` + mode flags).
                 `ref_text` is ignored for x-vector-only and required for ICL.
+            decoder_context_frames: Number of left-context codec frames used when
+                reconstructing successive streamed audio chunks. The default of 25
+                preserves the existing behavior.
             ref_spk/ref_rvq/ref_spk_emb/ref_codes: GGML-only cached reference fields.
                 Use `ref_spk` for qwentts.cpp `.spk` files and `ref_rvq` with
                 `ref_text` for cached ICL references.
@@ -1023,6 +1027,12 @@ class FasterQwen3TTS:
             ref_spk_emb=ref_spk_emb,
             ref_codes=ref_codes,
         )
+        if (
+            isinstance(decoder_context_frames, bool)
+            or not isinstance(decoder_context_frames, int)
+            or decoder_context_frames < 1
+        ):
+            raise ValueError("decoder_context_frames must be a positive integer")
 
         from .streaming import fast_generate_streaming, parity_generate_streaming
 
@@ -1047,9 +1057,9 @@ class FasterQwen3TTS:
 
         # Hybrid decode strategy:
         # 1. Accumulated decode for early chunks (correct, calibrates samples_per_frame)
-        # 2. Sliding window with 25-frame left context once calibrated (constant cost)
+        # 2. Sliding window with the configured left context once calibrated
         # This avoids boundary artifacts (pops) while keeping decode cost bounded.
-        context_frames = 25
+        context_frames = decoder_context_frames
         min_calibration_frames = max(context_frames, chunk_size)
         all_codes = []
         prev_gen_audio_len = 0  # tracks position within the generated (non-ref) audio

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -65,7 +65,7 @@ def test_public_api_exposes_voice_clone_prompt_parameter():
     assert list(sig_clone.parameters).index("max_new_tokens") == 5
     assert list(sig_stream.parameters).index("max_new_tokens") == 5
     assert list(sig_clone.parameters)[-1] == "voice_clone_prompt"
-    assert list(sig_stream.parameters)[-1] == "voice_clone_prompt"
+    assert list(sig_stream.parameters)[-1] == "decoder_context_frames"
     assert sig_clone.parameters["xvec_only"].default is False
     assert sig_clone.parameters["non_streaming_mode"].default is None
     assert sig_stream.parameters["xvec_only"].default is False
@@ -143,6 +143,73 @@ def test_public_api_uses_none_sentinel_for_non_streaming_overrides():
     assert sig_custom_stream.parameters["non_streaming_mode"].default is None
     assert sig_design.parameters["non_streaming_mode"].default is None
     assert sig_design_stream.parameters["non_streaming_mode"].default is None
+
+
+def test_voice_clone_streaming_exposes_decoder_context_frames():
+    signature = inspect.signature(FasterQwen3TTS.generate_voice_clone_streaming)
+
+    assert signature.parameters["decoder_context_frames"].default == 25
+
+
+@pytest.mark.parametrize("invalid_value", [True, 0, -1, 25.0])
+def test_voice_clone_streaming_rejects_invalid_decoder_context_frames(invalid_value):
+    model = _build_dummy_model()
+
+    with pytest.raises(ValueError, match="positive integer"):
+        next(
+            model.generate_voice_clone_streaming(
+                text="hello",
+                language="English",
+                decoder_context_frames=invalid_value,
+            )
+        )
+
+
+def test_voice_clone_streaming_uses_requested_decoder_context(monkeypatch):
+    import faster_qwen3_tts.streaming as streaming
+
+    model = _build_dummy_model()
+    decoded_frame_counts = []
+
+    class RecordingSpeechTokenizer:
+        def decode(self, payload):
+            frame_count = int(payload["audio_codes"].shape[1])
+            decoded_frame_counts.append(frame_count)
+            return [torch.zeros(frame_count * 2, dtype=torch.float32)], 24_000
+
+    prepared_model = types.SimpleNamespace(speech_tokenizer=RecordingSpeechTokenizer())
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation",
+        lambda **_kwargs: (
+            prepared_model,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            None,
+        ),
+    )
+
+    def fake_stream(**_kwargs):
+        for _ in range(10):
+            yield torch.zeros(12, 16, dtype=torch.long), {}
+
+    monkeypatch.setattr(streaming, "fast_generate_streaming", fake_stream)
+
+    chunks = list(
+        model.generate_voice_clone_streaming(
+            text="hello",
+            language="English",
+            chunk_size=12,
+            decoder_context_frames=100,
+        )
+    )
+
+    assert len(chunks) == 10
+    assert decoded_frame_counts == [12, 24, 36, 48, 60, 72, 84, 96, 108, 112]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Expose the voice-cloning streaming decoder context through a new `decoder_context_frames` argument.

This is a focused follow-up to #127 for the voice-cloning streaming path.

## Motivation

`generate_voice_clone_streaming()` currently hardcodes a 25-frame left-context window when reconstructing successive audio chunks. Making the existing window configurable lets callers evaluate continuity versus decoder cost without changing the backward-compatible default.

## Changes

- Add `decoder_context_frames: int = 25` to `generate_voice_clone_streaming()`.
- Reject booleans, non-integers, and values below 1 with a clear `ValueError`.
- Use the requested value for calibration and the rolling decode window.
- Document the option and add focused API and decode-window tests.

## Validation

- Focused API suite: 37 passed.
- Full suite: 64 passed, 15 skipped.
- `uvx ruff check faster_qwen3_tts tests`: passed.
- `git diff --check`: passed.