### PR TITLE
Expose decoder context for VoiceDesign streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ CUDA graphs support streaming output — audio chunks are yielded during generat
 
 Smaller chunks = lower latency but more decode overhead. `chunk_size=2` is the smallest that stays real-time on Jetson.
 
+`generate_voice_design_streaming()` accepts `decoder_context_frames` to tune the left-context window used for successive audio chunks. The default remains `25` for backward compatibility; callers can evaluate larger values when continuity is more important than decoder cost.
+
 **Model seed:** All the different model modes are effectively the same speed. The first time you clone a voice, it takes longer, but later it's cached. Use `benchmarks/compare_modes.py` to reproduce. Example on 0.6B, `chunk_size=8`:
 
 | Mode | TTFA (ms) | RTF | ms/step |

--- a/faster_qwen3_tts/model.py
+++ b/faster_qwen3_tts/model.py
@@ -1419,9 +1419,16 @@ class FasterQwen3TTS:
         do_sample: bool = True,
         repetition_penalty: float = 1.05,
         chunk_size: int = 12,
+        decoder_context_frames: int = 25,
     ) -> Generator[Tuple[np.ndarray, int, dict], None, None]:
         if self.model.model.tts_model_type != "voice_design":
             raise ValueError("Loaded model does not support voice design generation")
+        if (
+            isinstance(decoder_context_frames, bool)
+            or not isinstance(decoder_context_frames, int)
+            or decoder_context_frames < 1
+        ):
+            raise ValueError("decoder_context_frames must be a positive integer")
 
         self.model._validate_languages([language])
 
@@ -1442,7 +1449,7 @@ class FasterQwen3TTS:
 
         speech_tokenizer = m.speech_tokenizer
 
-        context_frames = 25
+        context_frames = decoder_context_frames
         min_calibration_frames = max(context_frames, chunk_size)
         all_codes = []
         prev_audio_len = 0

--- a/tests/test_voice_clone_prompt_api.py
+++ b/tests/test_voice_clone_prompt_api.py
@@ -145,6 +145,77 @@ def test_public_api_uses_none_sentinel_for_non_streaming_overrides():
     assert sig_design_stream.parameters["non_streaming_mode"].default is None
 
 
+def test_voice_design_streaming_exposes_decoder_context_frames():
+    signature = inspect.signature(FasterQwen3TTS.generate_voice_design_streaming)
+
+    assert signature.parameters["decoder_context_frames"].default == 25
+    assert list(signature.parameters)[-1] == "decoder_context_frames"
+
+
+@pytest.mark.parametrize("invalid_value", [True, 0, -1, 25.0])
+def test_voice_design_streaming_rejects_invalid_decoder_context_frames(invalid_value):
+    model = _build_dummy_model()
+    model.model.model.tts_model_type = "voice_design"
+
+    with pytest.raises(ValueError, match="positive integer"):
+        next(
+            model.generate_voice_design_streaming(
+                text="hello",
+                instruct="bright radio voice",
+                language="English",
+                decoder_context_frames=invalid_value,
+            )
+        )
+
+
+def test_voice_design_streaming_uses_requested_decoder_context(monkeypatch):
+    import faster_qwen3_tts.streaming as streaming
+
+    model = _build_dummy_model()
+    model.model.model.tts_model_type = "voice_design"
+    decoded_frame_counts = []
+
+    class RecordingSpeechTokenizer:
+        def decode(self, payload):
+            frame_count = int(payload["audio_codes"].shape[1])
+            decoded_frame_counts.append(frame_count)
+            return [torch.zeros(frame_count * 2, dtype=torch.float32)], 24_000
+
+    prepared_model = types.SimpleNamespace(speech_tokenizer=RecordingSpeechTokenizer())
+    monkeypatch.setattr(
+        model,
+        "_prepare_generation_custom",
+        lambda **_kwargs: (
+            prepared_model,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        ),
+    )
+
+    def fake_stream(**_kwargs):
+        for _ in range(10):
+            yield torch.zeros(12, 16, dtype=torch.long), {}
+
+    monkeypatch.setattr(streaming, "fast_generate_streaming", fake_stream)
+
+    chunks = list(
+        model.generate_voice_design_streaming(
+            text="hello",
+            instruct="bright radio voice",
+            language="English",
+            chunk_size=12,
+            decoder_context_frames=100,
+        )
+    )
+
+    assert len(chunks) == 10
+    assert decoded_frame_counts == [12, 24, 36, 48, 60, 72, 84, 96, 108, 112]
+
+
 @pytest.mark.parametrize(
     ("method_name", "kwargs", "expected_default"),
     [


### PR DESCRIPTION
## Summary

Expose the VoiceDesign streaming decoder context through a new `decoder_context_frames` argument.

This is a focused follow-up to #127 for the VoiceDesign streaming path.

## Motivation

`generate_voice_design_streaming()` currently hardcodes a 25-frame left-context window when reconstructing successive audio chunks. Making the existing window configurable lets callers evaluate continuity versus decoder cost without changing the backward-compatible default.

## Changes

- Add `decoder_context_frames: int = 25` to `generate_voice_design_streaming()`.
- Reject booleans, non-integers, and values below 1 with a clear `ValueError`.
- Use the requested value for calibration and the rolling decode window.
- Document the option and add focused API and decode-window tests.

## Validation

- Focused API suite: 37 passed.
- Full suite: 64 passed, 15 skipped.
- `uvx ruff check faster_qwen3_tts tests`: passed.
- `git diff --check`: passed.